### PR TITLE
refactor: use explicit db engine imports

### DIFF
--- a/backend/api/routers/crash.py
+++ b/backend/api/routers/crash.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..auth import get_current_user
-from .. import db
+from ..db import engine
 from ..models import Round, User
 from .metrics import rtp_observed
 
@@ -27,7 +27,7 @@ class RoundReq(BaseModel):
 
 @router.post("/round")
 def crash_round(body: RoundReq, user: User = Depends(get_current_user)) -> dict[str, Any]:
-    with Session(db.engine) as s:
+    with Session(engine) as s:
         existing = s.scalar(select(Round).where(Round.idempotency_key == body.idem))
         if existing:
             return {"round_id": existing.id, "payout": float(existing.payout)}
@@ -46,7 +46,7 @@ def crash_round(body: RoundReq, user: User = Depends(get_current_user)) -> dict[
     rng.raise_for_status()
     data = rng.json()
     payout = body.bet * Decimal(str(data["multiplier"]))
-    with Session(db.engine) as s, s.begin():
+    with Session(engine) as s, s.begin():
         round_obj = Round(
             user_id=user.id,
             bet=body.bet,

--- a/backend/api/routers/wallet.py
+++ b/backend/api/routers/wallet.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..auth import get_current_user
-from .. import db
+from ..db import engine
 from ..models import User
 from ..services.wallet import apply_transaction
 
@@ -21,7 +21,7 @@ class TxnReq(BaseModel):
 
 @router.post("/txn")
 def wallet_txn(body: TxnReq, user: User = Depends(get_current_user)) -> dict[str, Any]:
-    with Session(db.engine) as s, s.begin():
+    with Session(engine) as s, s.begin():
         entry = apply_transaction(s, user.id, body.amount, body.reason, body.idempotency_key)
         balance = float(entry.balance_after)
     return {"balance": balance}


### PR DESCRIPTION
## Summary
- import database engine directly instead of importing the whole db module
- update routers to reference engine via direct import

## Testing
- `pytest -q` *(fails: connection to Postgres at 127.0.0.1:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a74fe3746c83289a2c0fb3c2114d22