### PR TITLE
Fix Dockerfile port env variable expansion

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,4 +10,5 @@ COPY --from=builder /usr/local /usr/local
 COPY . .
 ENV PATH=/usr/local/bin:$PATH
 EXPOSE 8000
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "$PORT", "--proxy-headers", "--forwarded-allow-ips", "*"]
+# Use a shell command so the PORT environment variable is expanded at runtime
+CMD ["sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port $PORT --proxy-headers --forwarded-allow-ips '*'" ]


### PR DESCRIPTION
## Summary
- ensure PORT environment variable is expanded by using shell form in backend Dockerfile

## Testing
- `make test` *(fails: test_crash_round.py:2:8: F811 Redefinition of unused `os`; tests/test_metrics.py:16:1: E402 Module level import not at top of file; tests/test_rng.py:16:1: E402 Module level import not at top of file)*

------
https://chatgpt.com/codex/tasks/task_e_68a75224cfe88328bfa06b9cca49540e