### PR TITLE
Fix PostgreSQL driver handling and use shared DB engine

### DIFF
--- a/backend/api/db.py
+++ b/backend/api/db.py
@@ -7,6 +7,18 @@ from sqlalchemy.pool import StaticPool
 from .models import Base
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
+
+# SQLAlchemy defaults to the legacy ``psycopg2`` driver when given a URL
+# beginning with ``postgresql://``. The project depends on ``psycopg`` (the
+# modern Psycopg 3 driver) instead, so we transparently upgrade any plain
+# Postgres URLs to explicitly request that driver. This prevents a
+# ``ModuleNotFoundError`` for ``psycopg2`` at runtime when the application is
+# deployed with a Postgres database.
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+psycopg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+psycopg://", 1)
+
 _engine_args: dict[str, Any] = {"future": True}
 if DATABASE_URL.startswith("sqlite") and ":memory:" in DATABASE_URL:
     _engine_args.update(connect_args={"check_same_thread": False}, poolclass=StaticPool)

--- a/backend/api/routers/wallet.py
+++ b/backend/api/routers/wallet.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..auth import get_current_user
-from ..db import engine
+from .. import db
 from ..models import User
 from ..services.wallet import apply_transaction
 
@@ -21,7 +21,7 @@ class TxnReq(BaseModel):
 
 @router.post("/txn")
 def wallet_txn(body: TxnReq, user: User = Depends(get_current_user)) -> dict[str, Any]:
-    with Session(engine) as s, s.begin():
+    with Session(db.engine) as s, s.begin():
         entry = apply_transaction(s, user.id, body.amount, body.reason, body.idempotency_key)
         balance = float(entry.balance_after)
     return {"balance": balance}

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "backend"))
+
+def test_postgres_url_uses_psycopg(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost/db")
+    if "api.db" in sys.modules:
+        del sys.modules["api.db"]
+    import api.db as db  # noqa: E402
+    assert db.engine.url.drivername == "postgresql+psycopg"
+    # Clean up so other tests can configure their own database URL
+    del sys.modules["api.db"]


### PR DESCRIPTION
## Summary
- ensure DATABASE_URL uses psycopg driver when deploying to PostgreSQL
- reference db.engine dynamically in wallet and crash routers
- add regression test for psycopg driver detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a753485efc832892ad9931d46187bb