### PR TITLE
Add root redirect to Swagger docs

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
 import os
 
 from .middleware.ratelimit import RateLimitMiddleware
@@ -36,6 +37,11 @@ app.add_middleware(RateLimitMiddleware)
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+# Redirect root to Swagger docs
+@app.get("/", include_in_schema=False)
+def root():
+    return RedirectResponse(url="/docs")
 
 # Incluí routers si existen
 if wallet:


### PR DESCRIPTION
## Summary
- redirect API root to `/docs`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a755f86fc48328af738904f379ba29