### PR TITLE
Add minimal Node package files for Render build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "gaming-fastapi",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gaming-fastapi",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "gaming-fastapi",
+  "version": "1.0.0",
+  "description": "Auxiliary package for Render build; no dependencies.",
+  "scripts": {
+    "build": "echo \"No build step\""
+  },
+  "license": "ISC"
+}


### PR DESCRIPTION
## Summary
- add a minimal package.json and package-lock.json so `npm ci` can run during deploys

## Testing
- `npm ci`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Cannot install httpx==0.27.0 and httpx==0.27.2 because these package versions have conflicting dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a75cfdebf48328bc6973a76dd3d496