### PR TITLE
fix build script to generate dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Auxiliary package for Render build; no dependencies.",
   "scripts": {
-    "build": "echo \"No build step\""
+    "build": "mkdir -p dist && cp -r frontend/* dist/"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
## Summary
- copy frontend assets into a dist directory during `npm run build` to satisfy Render static site publish step

## Testing
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a75f7842608328a2bcea9f70f8fbd8