### PR TITLE
fix build script for render static build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Auxiliary package for Render build; no dependencies.",
   "scripts": {
-    "build": "mkdir -p dist && cp -r frontend/* dist/"
+    "build": "node tools/build.js"
   },
   "license": "ISC"
 }

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const distDir = path.join(repoRoot, 'dist');
+const srcDir = path.join(repoRoot, 'frontend');
+
+// Clean any existing dist directory
+fs.rmSync(distDir, { recursive: true, force: true });
+fs.mkdirSync(distDir, { recursive: true });
+
+// Copy contents of frontend to dist
+fs.cpSync(srcDir, distDir, { recursive: true });


### PR DESCRIPTION
## Summary
- use node script to copy frontend files into dist
- ensure dist directory recreated from frontend during build

## Testing
- `npm run build`
- `pip install -r requirements.txt` (fails: Cannot install httpx==0.27.0 and httpx==0.27.2)
- `pytest -q` (fails: ModuleNotFoundError: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68a760840a88832899c54c5cedc66b08