### PR TITLE
fix build script to generate dist folder

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -5,9 +5,29 @@ const repoRoot = path.resolve(__dirname, '..');
 const distDir = path.join(repoRoot, 'dist');
 const srcDir = path.join(repoRoot, 'frontend');
 
+function copyRecursive(src, dest) {
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(destPath, { recursive: true });
+      copyRecursive(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
 // Clean any existing dist directory
 fs.rmSync(distDir, { recursive: true, force: true });
 fs.mkdirSync(distDir, { recursive: true });
 
+if (!fs.existsSync(srcDir)) {
+  console.error(`Source directory not found: ${srcDir}`);
+  process.exit(1);
+}
+
 // Copy contents of frontend to dist
-fs.cpSync(srcDir, distDir, { recursive: true });
+copyRecursive(srcDir, distDir);
+console.log(`Static assets copied to ${distDir}`);


### PR DESCRIPTION
## Summary
- add recursive copy utility to build script so static assets are copied into `dist`

## Testing
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a7627159bc8328bb29ed0e79ea5095