### PR TITLE
chore: configure Vite build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "description": "Auxiliary package for Render build; no dependencies.",
   "scripts": {
-    "build": "node tools/build.js"
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
   },
   "license": "ISC"
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react-swc'
+
+export default defineConfig({
+  root: 'frontend',            // acá está tu index.html
+  plugins: [react()],
+  build: {
+    outDir: 'dist',            // => genera frontend/dist
+    emptyOutDir: true
+  },
+  server: { port: 5173 },
+  preview: { port: 5173 }
+})
+


### PR DESCRIPTION
## Summary
- add Vite config pointing to frontend directory
- simplify npm scripts to use Vite

## Testing
- `pip install -r requirements.txt` *(fails: Cannot install httpx==0.27.0 and httpx==0.27.2 because these package versions have conflicting dependencies)*
- `pytest -q`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a765988fd48328a553685a00f7609c