### PR TITLE
fix: resolve dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,8 @@ python-jose[cryptography]==3.3.0
 python-dotenv==1.0.1
 httpx==0.27.2
 email-validator==2.2.0
-httpx==0.27.0
 pytest==8.2.2
-email-validator==2.2.0
-pytest==8.2.0
-
 alembic==1.13.1
-email-validator==2.2.0
 psycopg2-binary==2.9.10
-
 numpy==1.26.4
 locust==2.24.0


### PR DESCRIPTION
## Summary
- remove duplicated dependencies from requirements
- keep httpx 0.27.2 to avoid conflicting versions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76830cc288328ab1845af41ec9823