### PR TITLE
Handle HEAD requests for root endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn main:app --reload --port 8000
+uvicorn api.main:app --reload --port 8000
 ```
 Abrí `http://127.0.0.1:8000/docs` para probar.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,7 +12,7 @@ Endpoints (dev):
 cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn main:app --reload --port 8000
+uvicorn api.main:app --reload --port 8000
 ```
 
 Then open `http://127.0.0.1:8000/docs` for Swagger UI.

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2,18 +2,21 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 import os
+from types import ModuleType
+from typing import Optional
 
 from .middleware.ratelimit import RateLimitMiddleware
 from .auth import router as auth_router
 
 # Routers (importá solo los que existan en tu proyecto)
+wallet: Optional[ModuleType] = None
+crash: Optional[ModuleType] = None
+me: Optional[ModuleType] = None
+metrics: Optional[ModuleType] = None
 try:
-    from .routers import wallet, crash, me, metrics
+    from .routers import wallet as wallet, crash as crash, me as me, metrics as metrics  # type: ignore
 except Exception:
-    wallet = None
-    crash = None
-    me = None
-    metrics = None
+    pass
 
 app = FastAPI(title="FastAPI", version="0.1.0")
 
@@ -38,9 +41,9 @@ app.add_middleware(RateLimitMiddleware)
 def health():
     return {"status": "ok"}
 
-# Redirect root to Swagger docs
-@app.get("/", include_in_schema=False)
-def root():
+# Redirect root to Swagger docs, handling both GET and HEAD
+@app.api_route("/", methods=["GET", "HEAD"], include_in_schema=False)
+async def root() -> RedirectResponse:
     return RedirectResponse(url="/docs")
 
 # Incluí routers si existen


### PR DESCRIPTION
## Summary
- Accept HEAD and GET on root path so health checks redirect properly
- Add typing for optional routers to satisfy mypy
- Correct README run commands to use `uvicorn api.main:app`

## Testing
- `ruff check backend/api/main.py`
- `mypy --ignore-missing-imports backend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77b2f3a9c8328b0b2fbe5bd1bc818