### PR TITLE
Split login and register into dedicated pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ uvicorn api.main:app --reload --port 8000
 Abrí `http://127.0.0.1:8000/docs` para probar.
 
 2) **Frontend**
-Abrí `frontend/index.html` en tu navegador. (Si tu navegador bloquea CORS, servilo con un servercito local, por ejemplo:
+Primero abrí `frontend/login.html` para loguearte o registrarte. Luego serás redirigido a `index.html` (el juego).
+Si tu navegador bloquea CORS, servilo con un servercito local, por ejemplo:
 ```bash
 # en la carpeta frontend
 python -m http.server 8080

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -1,0 +1,6 @@
+const API_BASE = "http://127.0.0.1:8000";
+
+function setToken(t){ localStorage.setItem("token", t); }
+function getToken(){ return localStorage.getItem("token"); }
+function clearToken(){ localStorage.removeItem("token"); }
+function isAuthed(){ return !!getToken(); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,6 +24,7 @@
     .meta { font-size:12px; opacity:.8; margin-top:8px; word-break: break-all; }
   </style>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/8.2.5/pixi.min.js"></script>
+  <script src="auth.js"></script>
 </head>
 <body>
   <header>
@@ -40,12 +41,6 @@
         <b>Auth</b>
         <span class="pill" id="status">Desconectado</span>
         <span class="pill" id="balance">Balance: -</span>
-      </div>
-      <div class="row" style="margin-top:10px;">
-        <input id="email" type="email" placeholder="email@example.com" />
-        <input id="password" type="password" placeholder="password" />
-        <button id="btnRegister">Registrar</button>
-        <button id="btnLogin">Login</button>
         <button id="btnLogout">Logout</button>
       </div>
     </div>
@@ -67,14 +62,8 @@
   </div>
 
 <script>
-const API_BASE = "http://127.0.0.1:8000";
-
 const statusEl = document.getElementById("status");
 const balEl = document.getElementById("balance");
-const emailEl = document.getElementById("email");
-const passEl = document.getElementById("password");
-const btnReg = document.getElementById("btnRegister");
-const btnLogin = document.getElementById("btnLogin");
 const btnLogout = document.getElementById("btnLogout");
 
 const logEl = document.getElementById("log");
@@ -85,10 +74,7 @@ const healthEl = document.getElementById("health");
 const metaEl = document.getElementById("meta");
 const playBtn = document.getElementById("playBtn");
 
-function setToken(t){ localStorage.setItem("token", t); }
-function getToken(){ return localStorage.getItem("token"); }
-function clearToken(){ localStorage.removeItem("token"); }
-function isAuthed(){ return !!getToken(); }
+if(!isAuthed()) location.href = "login.html";
 
 function log(s){
   const t = new Date().toLocaleTimeString();
@@ -106,11 +92,6 @@ async function health(){
 setInterval(health, 3000); health();
 
 async function refreshMe(){
-  if(!isAuthed()){
-    statusEl.textContent = "Desconectado";
-    balEl.textContent = "Balance: -";
-    return;
-  }
   statusEl.textContent = "Conectado";
   try{
     const r = await fetch(API_BASE + "/account", {
@@ -122,6 +103,7 @@ async function refreshMe(){
     }else{
       statusEl.textContent = "Token inválido";
       clearToken();
+      location.href = "login.html";
     }
   }catch(e){
     statusEl.textContent = "Error";
@@ -129,31 +111,7 @@ async function refreshMe(){
 }
 refreshMe();
 
-btnReg.onclick = async () => {
-  const email = emailEl.value.trim(), password = passEl.value;
-  if(!email || !password) return alert("Completá email y password");
-  const r = await fetch(API_BASE + "/auth/register", {
-    method: "POST", headers: { "Content-Type":"application/json" },
-    body: JSON.stringify({ email, password })
-  });
-  const j = await r.json();
-  if(r.ok){ setToken(j.token); refreshMe(); log("Registro OK (+100 de bienvenida)"); }
-  else log("Error: " + JSON.stringify(j));
-};
-
-btnLogin.onclick = async () => {
-  const email = emailEl.value.trim(), password = passEl.value;
-  if(!email || !password) return alert("Completá email y password");
-  const r = await fetch(API_BASE + "/auth/login", {
-    method: "POST", headers: { "Content-Type":"application/json" },
-    body: JSON.stringify({ email, password })
-  });
-  const j = await r.json();
-  if(r.ok){ setToken(j.token); refreshMe(); log("Login OK"); }
-  else log("Error: " + JSON.stringify(j));
-};
-
-btnLogout.onclick = () => { clearToken(); refreshMe(); log("Logout"); };
+btnLogout.onclick = () => { clearToken(); location.href = "login.html"; };
 
 // ---- PIXI ----
 const app = new PIXI.Application();

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Login - Crash MVP</title>
+  <style>
+    :root { color-scheme: dark; }
+    body { font-family: system-ui, sans-serif; margin:0; background:#0f1220; color:#eaeaf2; }
+    .wrap { padding:16px; max-width:480px; margin:0 auto; }
+    .card { background:#10142a; border-radius:14px; padding:16px; }
+    .row { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+    input, button {
+      padding: 10px 12px; border-radius: 10px; border: 1px solid #2a2f55;
+      background: #1b2045; color: #fff; outline: none;
+    }
+    button { cursor: pointer; }
+    .log { margin-top:12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background:#0b0e1d; padding:12px; border-radius:8px; height:120px; overflow:auto; }
+  </style>
+  <script src="auth.js"></script>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Login</h1>
+    <div class="card">
+      <div class="row">
+        <input id="email" type="email" placeholder="email@example.com" />
+        <input id="password" type="password" placeholder="password" />
+        <button id="btnLogin">Login</button>
+      </div>
+      <p>¿No tenés cuenta? <a href="register.html">Registrate</a></p>
+      <div class="log" id="log"></div>
+    </div>
+  </div>
+<script>
+if(isAuthed()) location.href = "index.html";
+
+const emailEl = document.getElementById("email");
+const passEl = document.getElementById("password");
+const btnLogin = document.getElementById("btnLogin");
+const logEl = document.getElementById("log");
+
+function log(s){ const t = new Date().toLocaleTimeString(); logEl.innerHTML = `[${t}] ${s}<br/>` + logEl.innerHTML; }
+
+btnLogin.onclick = async () => {
+  const email = emailEl.value.trim(), password = passEl.value;
+  if(!email || !password) return alert("Completá email y password");
+  const r = await fetch(API_BASE + "/auth/login", {
+    method: "POST", headers: { "Content-Type":"application/json" },
+    body: JSON.stringify({ email, password })
+  });
+  const j = await r.json();
+  if(r.ok){ setToken(j.token); location.href = "index.html"; }
+  else log("Error: " + JSON.stringify(j));
+};
+</script>
+</body>
+</html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Registro - Crash MVP</title>
+  <style>
+    :root { color-scheme: dark; }
+    body { font-family: system-ui, sans-serif; margin:0; background:#0f1220; color:#eaeaf2; }
+    .wrap { padding:16px; max-width:480px; margin:0 auto; }
+    .card { background:#10142a; border-radius:14px; padding:16px; }
+    .row { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+    input, button {
+      padding: 10px 12px; border-radius: 10px; border: 1px solid #2a2f55;
+      background: #1b2045; color: #fff; outline: none;
+    }
+    button { cursor: pointer; }
+    .log { margin-top:12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background:#0b0e1d; padding:12px; border-radius:8px; height:120px; overflow:auto; }
+  </style>
+  <script src="auth.js"></script>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Registro</h1>
+    <div class="card">
+      <div class="row">
+        <input id="email" type="email" placeholder="email@example.com" />
+        <input id="password" type="password" placeholder="password" />
+        <button id="btnRegister">Registrar</button>
+      </div>
+      <p>¿Ya tenés cuenta? <a href="login.html">Login</a></p>
+      <div class="log" id="log"></div>
+    </div>
+  </div>
+<script>
+if(isAuthed()) location.href = "index.html";
+
+const emailEl = document.getElementById("email");
+const passEl = document.getElementById("password");
+const btnReg = document.getElementById("btnRegister");
+const logEl = document.getElementById("log");
+
+function log(s){ const t = new Date().toLocaleTimeString(); logEl.innerHTML = `[${t}] ${s}<br/>` + logEl.innerHTML; }
+
+btnReg.onclick = async () => {
+  const email = emailEl.value.trim(), password = passEl.value;
+  if(!email || !password) return alert("Completá email y password");
+  const r = await fetch(API_BASE + "/auth/register", {
+    method: "POST", headers: { "Content-Type":"application/json" },
+    body: JSON.stringify({ email, password })
+  });
+  const j = await r.json();
+  if(r.ok){ setToken(j.token); location.href = "index.html"; }
+  else log("Error: " + JSON.stringify(j));
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split authentication forms into separate login and registration pages
- add shared auth helper and redirect game to login when unauthenticated
- update README usage instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a77d9715488328a3dc5c23b49fc8de