### PR TITLE
feat: add configurable API base for frontend

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
-VITE_API_URL=https://gaming-fastapi.onrender.com
+# En prod (Render) usar vacío para same-origin + rewrites
+VITE_API_URL=

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,15 +1,9 @@
-const API = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
-export async function api(path: string, opts: RequestInit = {}) {
-  const r = await fetch(`${API}${path}`, {
-    headers: { "Content-Type": "application/json", ...(opts.headers || {}) },
-    ...opts,
-  });
-  if (!r.ok) throw new Error(`HTTP ${r.status}`);
-  return r.json();
-}
+import { api } from "../lib/api";
+
 export async function registerUser(p:{email:string; username:string; password:string}) {
   return api("/api/auth/register", { method: "POST", body: JSON.stringify(p) });
 }
+
 export async function loginUser(p:{email:string; password:string}) {
   return api("/api/auth/login", { method: "POST", body: JSON.stringify(p) });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,13 @@
+const BASE = (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "");
+const join = (p: string) => (p.startsWith("/") ? p : `/${p}`);
+
+export async function api(path: string, init: RequestInit = {}) {
+  const url = `${BASE}${join(path)}`;
+  const res = await fetch(url, {
+    headers: { "Content-Type": "application/json", ...(init.headers || {}) },
+    ...init,
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const ct = res.headers.get("content-type") || "";
+  return ct.includes("application/json") ? res.json() : res.text();
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,13 @@ export default defineConfig({
   root: 'frontend',
   plugins: [react()],
   build: { outDir: 'dist', emptyOutDir: true },
-  server: { port: 5173 },
-  preview: { port: 5173 },
+  server: {
+    port: 5173,
+    proxy: { "/api": "http://localhost:8000" }
+  },
+  preview: {
+    port: 5173,
+    proxy: { "/api": "http://localhost:8000" }
+  },
 })
 


### PR DESCRIPTION
## Summary
- add configurable API helper and env defaults
- proxy API calls in Vite for dev

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.*)*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7878ea3e48328888a4e10e9cc17d6