### PR TITLE
Enable CORS origins and modularize auth script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See `backend/.env.example`.
 
 ### Frontend (`frontend/.env`)
 
-- `VITE_API_URL` - base URL for the backend API.
+- `VITE_API_URL` - base URL for the backend API (optional, defaults to same origin).
 
 See `frontend/.env.example`.
 
@@ -56,3 +56,16 @@ uvicorn api.main:app --host 0.0.0.0 --port 10000
 ```
 
 The static site publishes `frontend/dist` after running `npm ci && npm run build`.
+
+## Quick QA
+
+### Development
+
+1. Run the backend on port `8000`.
+2. In another terminal, run `npm run dev`.
+3. Use the register form to send a `POST` request to `/api/auth/register`.
+
+### Production (Render)
+
+The frontend on `https://gaming-fastapi-1.onrender.com` should issue requests to
+`https://gaming-fastapi.onrender.com` via the `/api/*` rewrite.

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -5,7 +5,6 @@ from types import ModuleType
 from typing import Optional
 
 from .middleware.ratelimit import RateLimitMiddleware
-from .settings import settings
 from .auth import router as auth_router
 
 # Routers (importá solo los que existan en tu proyecto)
@@ -20,9 +19,14 @@ except Exception:
 
 app = FastAPI(title="FastAPI", version="0.1.0")
 
+origins = [
+    "http://localhost:5173",
+    "https://gaming-fastapi-1.onrender.com",
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[str(o) for o in settings.CORS_ORIGINS] or ["*"],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-const API = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+const API = import.meta.env.VITE_API_URL || "";
 export async function api(path: string, opts: RequestInit = {}) {
   const r = await fetch(`${API}${path}`, {
     headers: { "Content-Type": "application/json", ...(opts.headers || {}) },

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,0 +1,3 @@
+import { initRegisterPage } from "./pages/register";
+
+initRegisterPage();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,1 @@
-import { initRegisterPage } from "./pages/register";
-
-initRegisterPage();
+import "./auth";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,15 @@ export default defineConfig({
   root: 'frontend',
   plugins: [react()],
   build: { outDir: 'dist', emptyOutDir: true },
-  server: { port: 5173 },
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      }
+    }
+  },
   preview: { port: 5173 },
 })
 


### PR DESCRIPTION
## Summary
- configure CORS for local and Render origins
- proxy API requests in Vite dev server and move auth script into module
- document quick QA steps for dev and prod

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a78889d4b483289e038f086d939b4a