### PR TITLE
Add username support to user registration

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -67,6 +67,7 @@ def register(data: RegisterIn) -> TokenOut:
         user = User(
             id=str(uuid.uuid4()),
             email=data.email,
+            username=data.username,
             password_hash=pwd_context.hash(data.password),
         )
         s.add(user)

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -12,6 +12,7 @@ class User(Base):
     __tablename__ = "users"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    username: Mapped[str] = mapped_column(String(50))
     password_hash: Mapped[str] = mapped_column(String(255))
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
 

--- a/backend/api/routers/me.py
+++ b/backend/api/routers/me.py
@@ -10,4 +10,4 @@ router = APIRouter()
 
 @router.get("/me")
 def me(user: User = Depends(get_current_user)) -> dict[str, Any]:
-    return {"id": user.id, "email": user.email}
+    return {"id": user.id, "email": user.email, "username": user.username}


### PR DESCRIPTION
## Summary
- persist usernames on the `users` table and registration endpoint
- expose the stored username from the `/me` endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78bab9b388328b0e764c1757d8afd