### PR TITLE
feat: configure CORS origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 ENV=development
 DATABASE_URL=postgresql+psycopg://user:password@localhost:5432/dbname
-ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+CORS_ORIGINS=https://gaming-fastapi-1.onrender.com,http://localhost:5173
 JWT_SECRET=changeme

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -8,7 +8,10 @@ class Settings(BaseSettings):
     JWT_SECRET: str = "changeme"  # se sobreescribe por env
     JWT_EXPIRES_MIN: int = 60
     DATABASE_URL: str = ""
-    CORS_ORIGINS: List[AnyHttpUrl] = []
+    CORS_ORIGINS: List[AnyHttpUrl] = [
+        AnyHttpUrl("https://gaming-fastapi-1.onrender.com"),
+        AnyHttpUrl("http://localhost:5173"),
+    ]
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
## Summary
- configure default CORS origins for backend including deployed front-end and local dev
- document CORS_ORIGINS in example env file

## Testing
- `ruff check .` (fails: F811, E402 etc.)
- `mypy --ignore-missing-imports .` (fails: 3 errors)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a790e1990083289e9d06991bc7068c