### PR TITLE
Configure CORS to allow frontend origins

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -5,7 +5,6 @@ from types import ModuleType
 from typing import Optional
 
 from .middleware.ratelimit import RateLimitMiddleware
-from .settings import settings
 from .auth import router as auth_router
 
 # Routers (importá solo los que existan en tu proyecto)
@@ -20,10 +19,16 @@ except Exception:
 
 app = FastAPI(title="FastAPI", version="0.1.0")
 
+# Allowed origins for CORS (exact, without trailing slash)
+ALLOWED_ORIGINS = [
+    "https://gaming-fastapi-1.onrender.com",
+    "http://localhost:5173",
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[str(o) for o in settings.CORS_ORIGINS] or ["*"],
-    allow_credentials=True,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- add explicit CORS origins for render and localhost
- disable credentialed CORS requests

## Testing
- ⚠️ `make test` (ruff errors in tests)
- ⚠️ `mypy --ignore-missing-imports .` (type errors in unrelated files)
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a79692c2d08328900276a0a55bea94