### PR TITLE
Fix CORS and standardize auth responses

### DIFF
--- a/test_crash_round.py
+++ b/test_crash_round.py
@@ -5,10 +5,12 @@ import types
 from pathlib import Path
 
 os.environ["DATABASE_URL"] = "postgresql+psycopg://user:pass@localhost/db"
+os.environ["RATE_LIMIT_PER_MIN"] = "1000"
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, select, func
 from sqlalchemy.orm import Session
+from api.auth import _create_token
 
 ROOT = Path(__file__).resolve().parent
 sys.path.append(str(ROOT / "backend"))
@@ -17,6 +19,7 @@ import api.main as main
 from api.models import Base, Round
 import api.db as db
 import api.routers.crash as crash_router
+import api.auth as auth
 
 
 def test_round_idempotency(monkeypatch):
@@ -24,6 +27,7 @@ def test_round_idempotency(monkeypatch):
         os.remove("test.db")
     engine = create_engine("sqlite:///test.db", connect_args={"check_same_thread": False})
     db.engine = engine
+    auth.engine = engine
     db.SessionLocal.configure(bind=engine)
     Base.metadata.create_all(engine)
 
@@ -68,10 +72,14 @@ def test_round_idempotency(monkeypatch):
 
     client = TestClient(main.app)
     body = {"bet": 10, "client_seed": "cs", "idem": "abc"}
+    token1 = _create_token("rate1")
+    token2 = _create_token("rate2")
+    headers1 = {"Authorization": f"Bearer {token1}"}
+    headers2 = {"Authorization": f"Bearer {token2}"}
 
-    r1 = client.post("/crash/round", json=body)
+    r1 = client.post("/crash/round", json=body, headers=headers1)
     assert r1.status_code == 200
-    r2 = client.post("/crash/round", json=body)
+    r2 = client.post("/crash/round", json=body, headers=headers2)
     assert r2.status_code == 200
     assert r1.json()["round_id"] == r2.json()["round_id"]
     assert len(calls) == 2

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+# ensure backend path and env
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend")))
+os.environ["DATABASE_URL"] = "postgresql+psycopg://user:pass@localhost/test"
+os.environ["RATE_LIMIT_PER_MIN"] = "1000"
+os.environ["JWT_SECRET"] = "change-me-please"
+
+import api.main as main  # noqa: E402
+
+client = TestClient(main.app)
+
+
+def test_preflight_register():
+    headers = {
+        "Origin": "http://localhost:5173",
+        "Access-Control-Request-Method": "POST",
+    }
+    res = client.options("/api/auth/register", headers=headers)
+    assert res.status_code == 200
+    assert res.headers.get("access-control-allow-origin") == "http://localhost:5173"
+    assert res.headers.get("access-control-allow-credentials") == "true"


### PR DESCRIPTION
## Summary
- configure CORS with explicit allowed origins and request logging
- standardize `/api/auth/register` and `/api/auth/login` responses and validations
- add health endpoint and tests including CORS preflight

## Testing
- `pytest tests/test_cors.py tests/test_wallet.py tests/test_security.py tests/test_metrics.py test_crash_round.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7ce336c0483289c3c88ee6c96e90a