### PR TITLE
Use env variable for API base URL

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,5 @@
-const API = "https://gaming-fastapi.onrender.com";
+// Use API URL from environment variables; default to same origin
+const API = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
 
 export async function http(path, { method = "GET", body, headers } = {}) {
   const res = await fetch(API + path, {


### PR DESCRIPTION
## Summary
- use VITE_API_URL to configure frontend API base URL

## Testing
- `npm run build`
- `make test` *(fails: ruff found 12 errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d28fc0c88328b7f0d7d6dbdd3c3b