### PR TITLE
Fix dev API connection and test path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the backend package is on the Python path so tests can import `api`
+backend_path = Path(__file__).resolve().parent / "backend"
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,10 @@
-// Use API URL from environment variables; default to same origin
-const API = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
+// Use API URL from environment variables; when developing without a custom
+// URL fall back to the local backend. This avoids network errors when the
+// frontend runs on Vite (port 5173) and the API listens on port 8000.
+const API = (
+  import.meta.env.VITE_API_URL ||
+  (import.meta.env.DEV ? "http://localhost:8000" : "")
+).replace(/\/$/, "");
 
 export async function http(path, { method = "GET", body, headers } = {}) {
   const res = await fetch(API + path, {


### PR DESCRIPTION
## Summary
- default frontend API calls to local backend when running in dev to avoid connection errors
- add pytest configuration to include backend package on import path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7d42423b083288974e53d719ce3b0