### PR TITLE
fix tailwind content configuration

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,1 +1,6 @@
-export default { plugins: { tailwindcss: {}, autoprefixer: {} } }
+import tailwindcss from "tailwindcss";
+import autoprefixer from "autoprefixer";
+
+export default {
+  plugins: [tailwindcss(), autoprefixer()],
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,1 +1,0 @@
-export default { content: ["./index.html","./src/**/*.{ts,tsx}"], theme: { extend: {} }, plugins: [] }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Auxiliary package for Render build; with frontend dependencies.",
   "type": "module",
   "scripts": {
-    "dev": "TAILWIND_CONFIG=frontend/tailwind.config.js vite",
-    "build": "TAILWIND_CONFIG=frontend/tailwind.config.js vite build",
+    "dev": "vite",
+    "build": "vite build",
     "lint": "eslint .",
-    "preview": "TAILWIND_CONFIG=frontend/tailwind.config.js vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ["./frontend/index.html", "./frontend/src/**/*.{ts,tsx}"] ,
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- ensure Tailwind scans frontend files by moving configuration to project root
- simplify PostCSS setup and NPM scripts

## Testing
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'api')*


------
https://chatgpt.com/codex/tasks/task_e_68a7d3dc15648328851f2af402e1824c