### PR TITLE
Add migration for username column

### DIFF
--- a/alembic/versions/5d2a2ff16c7e_add_username_to_users.py
+++ b/alembic/versions/5d2a2ff16c7e_add_username_to_users.py
@@ -1,0 +1,16 @@
+"""add username column to users"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "5d2a2ff16c7e"
+down_revision = "366efed92ee6"
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('username', sa.String(length=50), nullable=False, server_default=''))
+    op.alter_column('users', 'username', server_default=None)
+
+def downgrade() -> None:
+    op.drop_column('users', 'username')


### PR DESCRIPTION
## Summary
- add Alembic migration adding `username` column to `users`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7d86a459c83288cf04b1c1e0a77cb