### PR TITLE
Add admin panel and wallet management

### DIFF
--- a/backend/api/admin_routes.py
+++ b/backend/api/admin_routes.py
@@ -1,0 +1,121 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+from decimal import Decimal
+from passlib.hash import bcrypt
+
+from .db import get_session
+from .models import User, Wallet, Transaction
+from .security import get_current_admin, create_token
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+
+class LoginBody(BaseModel):
+    email: str
+    password: str
+
+
+@router.post("/login")
+def admin_login(body: LoginBody, db: Session = Depends(get_session)):
+    user = db.query(User).filter(User.email == body.email.lower()).first()
+    if not user or not bcrypt.verify(body.password, user.password_hash) or not user.is_admin:
+        raise HTTPException(401, "Credenciales inválidas")
+    return {"access_token": create_token(user), "token_type": "bearer"}
+
+
+class TxOut(BaseModel):
+    id: int
+    user_id: str
+    ttype: str
+    amount: Decimal
+    status: str
+    note: str | None = None
+    created_at: str
+
+
+@router.get("/transactions/pending", response_model=list[TxOut])
+def list_pending(db: Session = Depends(get_session), _: User = Depends(get_current_admin)):
+    q = db.query(Transaction).filter(Transaction.status == "pending").order_by(Transaction.created_at.desc()).limit(200)
+    return [
+        TxOut(
+            id=t.id,
+            user_id=t.user_id,
+            ttype=t.ttype,
+            amount=t.amount,
+            status=t.status,
+            note=t.note,
+            created_at=t.created_at.isoformat(),
+        )
+        for t in q.all()
+    ]
+
+
+class DecisionBody(BaseModel):
+    approve: bool = Field(..., description="true aprueba, false rechaza")
+    note: str | None = None
+
+
+@router.post("/transactions/{tx_id}/decide")
+def decide(tx_id: int, body: DecisionBody, db: Session = Depends(get_session), admin: User = Depends(get_current_admin)):
+    tx = db.get(Transaction, tx_id)
+    if not tx or tx.status != "pending":
+        raise HTTPException(404, "Transacción no encontrada o ya resuelta")
+
+    wallet = db.query(Wallet).filter(Wallet.user_id == tx.user_id).with_for_update().first()
+    if not wallet:
+        wallet = Wallet(user_id=tx.user_id, balance=Decimal("0"))
+        db.add(wallet)
+        db.flush()
+
+    if body.approve:
+        if tx.ttype in ("deposit", "adjustment"):
+            wallet.balance = (wallet.balance or Decimal("0")) + tx.amount
+        elif tx.ttype == "withdraw":
+            if wallet.balance < tx.amount:
+                raise HTTPException(400, "Saldo insuficiente para aprobar retiro")
+            wallet.balance = wallet.balance - tx.amount
+        tx.status = "approved"
+    else:
+        tx.status = "rejected"
+
+    tx.note = body.note
+    tx.approved_by = admin.id
+    db.commit()
+    return {"ok": True, "status": tx.status, "balance": str(wallet.balance)}
+
+
+class CreditBody(BaseModel):
+    email_or_user_id: str
+    amount: Decimal = Field(gt=0)
+    note: str | None = "Ajuste manual"
+
+
+@router.post("/credit")
+def credit(body: CreditBody, db: Session = Depends(get_session), admin: User = Depends(get_current_admin)):
+    user = None
+    if "@" in body.email_or_user_id:
+        user = db.query(User).filter(User.email == body.email_or_user_id.lower()).first()
+    else:
+        user = db.get(User, body.email_or_user_id)
+    if not user:
+        raise HTTPException(404, "Usuario no encontrado")
+
+    tx = Transaction(
+        user_id=user.id,
+        ttype="adjustment",
+        amount=body.amount,
+        status="approved",
+        note=body.note,
+        approved_by=admin.id,
+    )
+    wallet = db.query(Wallet).filter(Wallet.user_id == user.id).with_for_update().first()
+    if not wallet:
+        wallet = Wallet(user_id=user.id, balance=Decimal("0"))
+        db.add(wallet)
+        db.flush()
+
+    wallet.balance = (wallet.balance or Decimal("0")) + body.amount
+    db.add(tx)
+    db.commit()
+    return {"ok": True, "user_id": user.id, "balance": str(wallet.balance)}

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -10,7 +11,7 @@ from sqlalchemy.orm import Session
 from typing import Literal
 
 from .db import engine
-from .models import User
+from .models import User, Wallet
 from .settings import settings
 
 JWT_ALG = "HS256"
@@ -85,6 +86,7 @@ def register(data: RegisterIn) -> RegisterOut:
             password_hash=pwd_context.hash(data.password),
         )
         s.add(user)
+        s.add(Wallet(user_id=user.id, balance=Decimal("0")))
         user_id = user.id
     return RegisterOut(id=user_id, email=data.email, username=data.username)
 

--- a/backend/api/db.py
+++ b/backend/api/db.py
@@ -31,3 +31,12 @@ try:
     Base.metadata.create_all(engine)
 except Exception:
     pass
+
+
+def get_session():
+    """FastAPI dependency that provides a database session."""
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2,13 +2,16 @@ import os
 import logging
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse, JSONResponse
 from fastapi.exceptions import RequestValidationError
 from types import ModuleType
+from pathlib import Path
 from typing import Optional
 
 from .middleware.ratelimit import RateLimitMiddleware
 from .auth import router as auth_router
+from .admin_routes import router as admin_router
 
 # Routers (importá solo los que existan en tu proyecto)
 wallet: Optional[ModuleType] = None
@@ -24,6 +27,7 @@ app = FastAPI(title="FastAPI", version="0.1.0")
 
 DEFAULT_ORIGINS = [
     "https://gaming-fastapi-1.onrender.com",
+    "https://gaming-fastapi.onrender.com",
     "http://localhost:5173",
     "http://localhost:3000",
 ]
@@ -41,6 +45,9 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(RateLimitMiddleware)
+
+app.mount("/admin", StaticFiles(directory=Path(__file__).parent / "static" / "admin", html=True), name="admin")
+
 
 logger = logging.getLogger("uvicorn")
 
@@ -95,6 +102,7 @@ if metrics:
 
 # Auth router
 app.include_router(auth_router)
+app.include_router(admin_router)
 
 # Local run
 if __name__ == "__main__":

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -1,0 +1,38 @@
+import os, jwt
+from fastapi import HTTPException, Depends
+from fastapi.security import OAuth2PasswordBearer
+from datetime import datetime, timedelta
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from .db import get_session
+from .models import User
+
+JWT_SECRET = os.getenv("JWT_SECRET", "changeme")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/admin/login")
+
+
+class TokenData(BaseModel):
+    sub: str
+    exp: int
+    is_admin: bool
+
+
+def create_token(user: User) -> str:
+    payload = {
+        "sub": user.id,
+        "is_admin": user.is_admin,
+        "exp": int((datetime.utcnow() + timedelta(hours=8)).timestamp()),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+
+def get_current_admin(token: str = Depends(oauth2_scheme), db: Session = Depends(get_session)) -> User:
+    try:
+        data = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=401, detail="Token inválido")
+    user = db.get(User, data.get("sub"))
+    if not user or not data.get("is_admin") or not user.is_admin:
+        raise HTTPException(status_code=403, detail="No autorizado")
+    return user

--- a/backend/api/services/wallet.py
+++ b/backend/api/services/wallet.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from ..models import Account, LedgerEntry
+from ..models import Wallet, LedgerEntry
 
 
 def apply_transaction(
@@ -22,10 +22,10 @@ def apply_transaction(
         return existing
 
     acc = session.execute(
-        select(Account).where(Account.user_id == user_id).with_for_update()
+        select(Wallet).where(Wallet.user_id == user_id).with_for_update()
     ).scalar_one_or_none()
     if not acc:
-        acc = Account(user_id=user_id, balance=Decimal("100"))
+        acc = Wallet(user_id=user_id, balance=Decimal("100"))
         session.add(acc)
         session.flush()
 

--- a/backend/api/static/admin/index.html
+++ b/backend/api/static/admin/index.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="es">
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Admin · Gaming</title>
+<style>
+  body{margin:0;background:#0b0f19;color:#e6eaf2;font-family:system-ui,Segoe UI,Roboto}
+  .wrap{max-width:980px;margin:40px auto;padding:0 16px}
+  .card{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.12);border-radius:16px;overflow:hidden}
+  .hd,.ft{padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.12)}
+  .ft{border-top:1px solid rgba(255,255,255,.12);border-bottom:none}
+  .bd{padding:16px}
+  input,select,button{border-radius:10px;padding:.6rem .8rem;border:1px solid rgba(255,255,255,.15);background:rgba(0,0,0,.25);color:#e6eaf2}
+  button{cursor:pointer;font-weight:700}
+  .row{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+  table{width:100%;border-collapse:collapse}
+  th,td{padding:.6rem;border-bottom:1px solid rgba(255,255,255,.12);text-align:left}
+  th{color:#9aa3b2}
+  .ok{background:#22c55e;color:#04110a;border-color:transparent}
+  .warn{background:#f59e0b;color:#1b1304;border-color:transparent}
+</style>
+<div class="wrap">
+  <div class="card">
+    <div class="hd row">
+      <strong>Panel Admin</strong>
+      <span id="status" style="margin-left:auto;opacity:.8">Desconectado</span>
+    </div>
+    <div class="bd">
+      <div class="row" id="loginRow">
+        <input id="email" placeholder="admin email" type="email"/>
+        <input id="password" placeholder="password" type="password"/>
+        <button id="btnLogin" class="ok">Login</button>
+      </div>
+
+      <div id="app" style="display:none">
+        <div class="row" style="margin:14px 0">
+          <button id="btnReload">Refrescar pendientes</button>
+          <div style="margin-left:auto" class="row">
+            <input id="creditUser" placeholder="email o user_id"/>
+            <input id="creditAmount" placeholder="monto" type="number" step="0.01" min="0"/>
+            <button id="btnCredit" class="ok">Acreditar</button>
+          </div>
+        </div>
+
+        <table id="tbl">
+          <thead><tr><th>ID</th><th>User</th><th>Tipo</th><th>Monto</th><th>Nota</th><th>Fecha</th><th>Acción</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+    <div class="ft">Uso interno · Movimientos y saldos</div>
+  </div>
+</div>
+
+<script>
+  const API = location.origin + "/api/admin";
+  let token = localStorage.getItem("adm_token") || "";
+
+  const el = (id)=>document.getElementById(id);
+  const setStatus = (t)=> el("status").textContent = t;
+
+  function showApp(auth){
+    el("loginRow").style.display = auth ? "none" : "flex";
+    el("app").style.display = auth ? "block" : "none";
+    setStatus(auth ? "Autenticado" : "Desconectado");
+  }
+  showApp(!!token);
+
+  el("btnLogin")?.addEventListener("click", async ()=>{
+    const email = el("email").value.trim();
+    const password = el("password").value;
+    const r = await fetch(API+"/login",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({email,password})});
+    if(!r.ok){ alert("Login inválido"); return; }
+    const data = await r.json();
+    token = data.access_token; localStorage.setItem("adm_token", token);
+    showApp(true); loadPending();
+  });
+
+  async function loadPending(){
+    const r = await fetch(API+"/transactions/pending",{headers:{Authorization:"Bearer "+token}});
+    if(!r.ok){ if(r.status===401||r.status===403){ localStorage.removeItem("adm_token"); token=""; showApp(false); } return; }
+    const rows = await r.json();
+    const tbody = el("tbl").querySelector("tbody");
+    tbody.innerHTML = "";
+    rows.forEach(x=>{
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>${x.id}</td>
+        <td>${x.user_id}</td>
+        <td>${x.ttype}</td>
+        <td>${x.amount}</td>
+        <td>${x.note ?? ""}</td>
+        <td>${new Date(x.created_at).toLocaleString()}</td>
+        <td class="row">
+          <button class="ok" data-id="${x.id}" data-apr="1">Aprobar</button>
+          <button class="warn" data-id="${x.id}" data-apr="0">Rechazar</button>
+        </td>`;
+      tbody.appendChild(tr);
+    });
+  }
+
+  el("btnReload")?.addEventListener("click", loadPending);
+
+  el("tbl").addEventListener("click", async (e)=>{
+    const btn = e.target.closest("button"); if(!btn) return;
+    const id = btn.dataset.id; const approve = btn.dataset.apr === "1";
+    const note = approve ? "ok" : prompt("Motivo de rechazo (opcional)") || null;
+    const r = await fetch(API+`/transactions/${id}/decide`,{
+      method:"POST",
+      headers:{"Content-Type":"application/json", Authorization:"Bearer "+token},
+      body: JSON.stringify({approve, note})
+    });
+    if(!r.ok){ alert("Error al decidir"); return; }
+    loadPending();
+  });
+
+  el("btnCredit")?.addEventListener("click", async ()=>{
+    const email_or_user_id = el("creditUser").value.trim();
+    const amount = parseFloat(el("creditAmount").value);
+    if(!email_or_user_id || !(amount>0)) return alert("Completa usuario y monto");
+    const r = await fetch(API+"/credit",{
+      method:"POST",
+      headers:{"Content-Type":"application/json", Authorization:"Bearer "+token},
+      body: JSON.stringify({email_or_user_id, amount, note:"Ajuste manual"})
+    });
+    if(!r.ok){ alert("No se pudo acreditar"); return; }
+    el("creditAmount").value=""; alert("Acreditado ✔");
+  });
+
+  if(token) loadPending();
+</script>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ pytest==8.2.2
 numpy==1.26.4
 prometheus_client==0.20.0
 locust==2.24.0
+PyJWT==2.8.0

--- a/backend/seed_admin.py
+++ b/backend/seed_admin.py
@@ -1,0 +1,29 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from passlib.hash import bcrypt
+
+from api.models import Base, User, Wallet
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+engine = create_engine(DATABASE_URL, future=True)
+Session = sessionmaker(engine, expire_on_commit=False)
+
+
+def ensure_admin(email: str, password: str, username: str = "admin"):
+    with Session() as db:
+        user = db.query(User).filter(User.email == email.lower()).first()
+        if not user:
+            user = User(email=email.lower(), username=username, password_hash=bcrypt.hash(password), is_admin=True)
+            db.add(user); db.flush()
+            db.add(Wallet(user_id=user.id, balance=0))
+        else:
+            user.is_admin = True
+            if password:
+                user.password_hash = bcrypt.hash(password)
+        db.commit()
+        print("Admin listo:", user.email, "id:", user.id)
+
+
+if __name__ == "__main__":
+    ensure_admin(os.getenv("ADMIN_EMAIL","admin@local"), os.getenv("ADMIN_PASSWORD","admin123"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest==8.2.2
 alembic==1.13.1
 numpy==1.26.4
 locust==2.24.0
+PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- add wallet and transaction models with admin JWT auth
- expose admin routes to approve or credit transactions and static admin panel
- seed script and environment updates for PyJWT

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install pytest` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e333b1d8832895826cf62107b276