### PR TITLE
Add admin panel for player and coin management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Play from "./pages/Play";
 import Wallet from "./pages/Wallet";
 import Profile from "./pages/Profile";
 import Leaderboard from "./pages/Leaderboard";
+import Admin from "./pages/Admin";
 import { ToastProvider } from "./components/ui/toast";
 
 export default function App() {
@@ -15,6 +16,7 @@ export default function App() {
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/leaderboard" element={<Leaderboard />} />
+        <Route path="/admin" element={<Admin />} />
       </Routes>
     </ToastProvider>
   );

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from "react";
+import Navbar from "@/components/Navbar";
+import Card from "@/components/ui/card";
+import Input from "@/components/ui/input";
+import Button from "@/components/ui/button";
+
+interface User {
+  id: string;
+  email: string;
+  username: string;
+  balance: number;
+}
+
+export default function Admin() {
+  const [token, setToken] = useState(localStorage.getItem("admin_token") || "");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [users, setUsers] = useState<User[]>([]);
+  const [amounts, setAmounts] = useState<Record<string, string>>({});
+
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch("/api/admin/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setToken(data.access_token);
+      localStorage.setItem("admin_token", data.access_token);
+    }
+  }
+
+  useEffect(() => {
+    if (token) {
+      fetchUsers();
+    }
+  }, [token]);
+
+  async function fetchUsers() {
+    const res = await fetch("/api/admin/users", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUsers(data);
+    }
+  }
+
+  async function credit(userId: string) {
+    const amount = amounts[userId];
+    if (!amount) return;
+    await fetch("/api/admin/credit", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ email_or_user_id: userId, amount: parseFloat(amount) }),
+    });
+    setAmounts((a) => ({ ...a, [userId]: "" }));
+    fetchUsers();
+  }
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <Card className="max-w-sm w-full space-y-4">
+          <h2 className="text-xl font-bold">Admin Login</h2>
+          <form className="space-y-2" onSubmit={handleLogin}>
+            <Input
+              placeholder="Email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <Input
+              placeholder="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <Button type="submit" className="w-full">
+              Login
+            </Button>
+          </form>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="p-4 space-y-4">
+        <h1 className="text-2xl font-bold">Admin Panel</h1>
+        <table className="w-full text-left">
+          <thead>
+            <tr className="border-b border-gray-700">
+              <th>Email</th>
+              <th>Username</th>
+              <th>Balance</th>
+              <th className="w-48">Credit</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.id} className="border-b border-gray-800">
+                <td>{u.email}</td>
+                <td>{u.username}</td>
+                <td>{u.balance}</td>
+                <td className="space-x-2">
+                  <Input
+                    type="number"
+                    value={amounts[u.id] || ""}
+                    onChange={(e) =>
+                      setAmounts({ ...amounts, [u.id]: e.target.value })
+                    }
+                    className="w-24 inline-block"
+                  />
+                  <Button onClick={() => credit(u.id)}>Add</Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import uuid
+from decimal import Decimal
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+# Ensure project backend on path and set dummy DATABASE_URL before importing app
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "backend"))
+os.environ["DATABASE_URL"] = "postgresql+psycopg://user:pass@localhost/test"
+os.environ["RATE_LIMIT_PER_MIN"] = "1000"
+
+import api.main as main  # noqa: E402
+from api.models import Base, User, Wallet  # noqa: E402
+import api.db as db  # noqa: E402
+import api.security as security  # noqa: E402
+
+
+# Configure in-memory database
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+db.engine = engine
+db.SessionLocal.configure(bind=engine, expire_on_commit=False)
+Base.metadata.drop_all(db.engine)
+Base.metadata.create_all(db.engine)
+
+client = TestClient(main.app)
+
+
+def _create_user(email: str, is_admin: bool = False, balance: Decimal = Decimal("0")) -> User:
+    uid = str(uuid.uuid4())
+    user = User(
+        id=uid,
+        email=email,
+        username=email.split("@")[0],
+        password_hash="x",
+        is_admin=is_admin,
+    )
+    with Session(db.engine) as s, s.begin():
+        s.add(user)
+        s.add(Wallet(user_id=user.id, balance=balance))
+    class Dummy:
+        def __init__(self, id, is_admin):
+            self.id = id
+            self.is_admin = is_admin
+    return Dummy(uid, is_admin)
+
+
+def test_list_users():
+    admin = _create_user("admin@example.com", is_admin=True)
+    _create_user("alice@example.com", balance=Decimal("5"))
+    token = security.create_token(admin)
+    resp = client.get("/api/admin/users", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    users = resp.json()
+    assert any(u["email"] == "alice@example.com" and float(u["balance"]) == 5 for u in users)


### PR DESCRIPTION
## Summary
- add `/api/admin/users` endpoint to list players with balances
- create React admin page for login, user listing and coin credit
- add test for admin user listing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8819b0dd08328b66b68185518d541