### PR TITLE
Add user login and registration pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import Wallet from "./pages/Wallet";
 import Profile from "./pages/Profile";
 import Leaderboard from "./pages/Leaderboard";
 import Admin from "./pages/Admin";
+import Login from "./pages/Login";
+import Register from "./pages/Register";
 import { ToastProvider } from "./components/ui/toast";
 
 export default function App() {
@@ -17,6 +19,8 @@ export default function App() {
         <Route path="/profile" element={<Profile />} />
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/admin" element={<Admin />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
       </Routes>
     </ToastProvider>
   );

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -3,17 +3,70 @@ import BalanceBadge from "./BalanceBadge";
 import { cn } from "@/lib/utils";
 
 export default function Navbar() {
+  const token = localStorage.getItem("token");
+
   return (
     <nav className="flex items-center justify-between p-4 bg-gray-800/50 border-b border-neon-blue">
       <Link to="/" className="text-neon-pink font-bold">
         CrashGame
       </Link>
       <div className="flex items-center gap-4">
-        <NavLink to="/play" className={({ isActive }) => cn("hover:text-neon-pink", isActive && "text-neon-pink")}>Play</NavLink>
-        <NavLink to="/wallet" className={({ isActive }) => cn("hover:text-neon-pink", isActive && "text-neon-pink")}>Wallet</NavLink>
-        <NavLink to="/leaderboard" className={({ isActive }) => cn("hover:text-neon-pink", isActive && "text-neon-pink")}>Leaderboard</NavLink>
-        <NavLink to="/profile" className={({ isActive }) => cn("hover:text-neon-pink", isActive && "text-neon-pink")}>Profile</NavLink>
-        <BalanceBadge />
+        {token ? (
+          <>
+            <NavLink
+              to="/play"
+              className={({ isActive }) =>
+                cn("hover:text-neon-pink", isActive && "text-neon-pink")
+              }
+            >
+              Play
+            </NavLink>
+            <NavLink
+              to="/wallet"
+              className={({ isActive }) =>
+                cn("hover:text-neon-pink", isActive && "text-neon-pink")
+              }
+            >
+              Wallet
+            </NavLink>
+            <NavLink
+              to="/leaderboard"
+              className={({ isActive }) =>
+                cn("hover:text-neon-pink", isActive && "text-neon-pink")
+              }
+            >
+              Leaderboard
+            </NavLink>
+            <NavLink
+              to="/profile"
+              className={({ isActive }) =>
+                cn("hover:text-neon-pink", isActive && "text-neon-pink")
+              }
+            >
+              Profile
+            </NavLink>
+            <BalanceBadge />
+          </>
+        ) : (
+          <>
+            <NavLink
+              to="/login"
+              className={({ isActive }) =>
+                cn("hover:text-neon-pink", isActive && "text-neon-pink")
+              }
+            >
+              Login
+            </NavLink>
+            <NavLink
+              to="/register"
+              className={({ isActive }) =>
+                cn("hover:text-neon-pink", isActive && "text-neon-pink")
+              }
+            >
+              Register
+            </NavLink>
+          </>
+        )}
       </div>
     </nav>
   );

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import Card from "@/components/ui/card";
+import Input from "@/components/ui/input";
+import Button from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+import { useGameStore } from "@/lib/store";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const navigate = useNavigate();
+  const toast = useToast();
+  const { setBalance } = useGameStore();
+
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast(err.error || "Login failed");
+        return;
+      }
+      const data = await res.json();
+      localStorage.setItem("token", data.token);
+      // fetch balance for store
+      const balRes = await fetch("/wallet/balance", {
+        headers: { Authorization: `Bearer ${data.token}` },
+      });
+      if (balRes.ok) {
+        const bal = await balRes.json();
+        setBalance(bal.balance);
+      }
+      toast("Logged in");
+      navigate("/");
+    } catch {
+      toast("Login failed");
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="max-w-sm w-full space-y-4 p-4">
+        <h2 className="text-xl font-bold text-center">Login</h2>
+        <form className="space-y-2" onSubmit={handleLogin}>
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button type="submit" className="w-full">
+            Login
+          </Button>
+        </form>
+        <p className="text-sm text-center">
+          No account? {""}
+          <Link to="/register" className="text-neon-pink">
+            Register
+          </Link>
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import Card from "@/components/ui/card";
+import Input from "@/components/ui/input";
+import Button from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+
+export default function Register() {
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const navigate = useNavigate();
+  const toast = useToast();
+
+  async function handleRegister(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const res = await fetch("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, username, password }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast(err.error || "Registration failed");
+        return;
+      }
+      toast("Registered");
+      navigate("/login");
+    } catch {
+      toast("Registration failed");
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="max-w-sm w-full space-y-4 p-4">
+        <h2 className="text-xl font-bold text-center">Register</h2>
+        <form className="space-y-2" onSubmit={handleRegister}>
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input
+            type="text"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button type="submit" className="w-full">
+            Register
+          </Button>
+        </form>
+        <p className="text-sm text-center">
+          Already have an account? {""}
+          <Link to="/login" className="text-neon-pink">
+            Login
+          </Link>
+        </p>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add conditional auth links in Navbar to show login/register or app routes depending on token
- Wire up React routes for new Login and Register pages
- Implement user registration and login forms that persist JWT and update balance

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8a0ae6c688328932ae546cacb64cb