### PR TITLE
Handle empty JSON responses gracefully

### DIFF
--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -26,9 +26,11 @@ export default function Admin() {
       body: JSON.stringify({ email, password }),
     });
     if (res.ok) {
-      const data = await res.json();
-      setToken(data.access_token);
-      localStorage.setItem("admin_token", data.access_token);
+      const data = await res.json().catch(() => ({}));
+      if (data.access_token) {
+        setToken(data.access_token);
+        localStorage.setItem("admin_token", data.access_token);
+      }
     }
   }
 
@@ -43,8 +45,8 @@ export default function Admin() {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (res.ok) {
-      const data = await res.json();
-      setUsers(data);
+      const data = await res.json().catch(() => []);
+      setUsers(Array.isArray(data) ? data : []);
     }
   }
 

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -12,8 +12,8 @@ export default function Leaderboard() {
 
   useEffect(() => {
     fetch("/leaderboard")
-      .then((res) => res.json())
-      .then(setEntries)
+      .then((res) => (res.ok ? res.json().catch(() => []) : []))
+      .then((data) => setEntries(data))
       .catch(() => {});
   }, []);
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -26,15 +26,17 @@ export default function Login() {
         toast(err.error || "Login failed");
         return;
       }
-      const data = await res.json();
+      const data = await res.json().catch(() => ({}));
       localStorage.setItem("token", data.token);
       // fetch balance for store
       const balRes = await fetch("/wallet/balance", {
         headers: { Authorization: `Bearer ${data.token}` },
       });
       if (balRes.ok) {
-        const bal = await balRes.json();
-        setBalance(bal.balance);
+        const bal = await balRes.json().catch(() => ({}));
+        if (typeof bal.balance === "number") {
+          setBalance(bal.balance);
+        }
       }
       toast("Logged in");
       navigate("/");

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -16,12 +16,16 @@ export default function Profile() {
   useEffect(() => {
     const token = localStorage.getItem("token") || "";
     fetch("/me", { headers: { Authorization: `Bearer ${token}` } })
-      .then((res) => (res.ok ? res.json() : null))
+      .then((res) => (res.ok ? res.json().catch(() => null) : null))
       .then((data) => data && setUser(data))
       .catch(() => {});
     fetch("/wallet/balance", { headers: { Authorization: `Bearer ${token}` } })
-      .then((res) => res.json())
-      .then((data) => setBalance(data.balance))
+      .then((res) => (res.ok ? res.json().catch(() => ({})) : {}))
+      .then((data) => {
+        if (typeof data.balance === "number") {
+          setBalance(data.balance);
+        }
+      })
       .catch(() => {});
   }, [setBalance]);
 

--- a/frontend/src/pages/Wallet.tsx
+++ b/frontend/src/pages/Wallet.tsx
@@ -13,8 +13,12 @@ export default function Wallet() {
   useEffect(() => {
     const token = localStorage.getItem("token") || "";
     fetch("/wallet/balance", { headers: { Authorization: `Bearer ${token}` } })
-      .then((res) => res.json())
-      .then((data) => setBalance(data.balance))
+      .then((res) => (res.ok ? res.json().catch(() => ({})) : {}))
+      .then((data) => {
+        if (typeof data.balance === "number") {
+          setBalance(data.balance);
+        }
+      })
       .catch(() => {});
   }, [setBalance]);
 
@@ -33,8 +37,10 @@ export default function Wallet() {
       }),
     });
     if (res.ok) {
-      const data = await res.json();
-      setBalance(data.balance);
+      const data = await res.json().catch(() => ({}));
+      if (typeof data.balance === "number") {
+        setBalance(data.balance);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid frontend crashes by safely parsing JSON responses across pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8aa5f11348328b890549de5edd2bd