### PR TITLE
chore: set default json content type

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ const baseURL = raw.startsWith("http://") && !raw.includes("localhost") ? raw.re
 const api = axios.create({
   baseURL,
   withCredentials: true,
+  headers: { "Content-Type": "application/json" },
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- ensure axios sends JSON by default so FastAPI receives request bodies

## Testing
- `pytest` *(fails: tests/test_cors.py::test_preflight_register)*

------
https://chatgpt.com/codex/tasks/task_e_68abcd6dc9548328a1831992276e51ef