### PR TITLE
feat: redesign play screen with neon theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;700&display=swap"
     rel="stylesheet"
   />
   <link rel="stylesheet" href="/src/index.css" />

--- a/frontend/src/components/ActiveBetsPanel.tsx
+++ b/frontend/src/components/ActiveBetsPanel.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import Card from "@/components/ui/card";
+import Skeleton from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/toast";
+import { formatMoney, formatMultiplier } from "@/lib/utils";
+
+interface Bet {
+  id: number;
+  amount: number;
+  cashout: number;
+}
+
+export default function ActiveBetsPanel() {
+  const [bets, setBets] = React.useState<Bet[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const toast = useToast();
+
+  React.useEffect(() => {
+    fetch("/api/bets/active")
+      .then((res) => res.json())
+      .then((data) => setBets(data))
+      .catch(() => toast("Error cargando apuestas"))
+      .finally(() => setLoading(false));
+  }, [toast]);
+
+  return (
+    <Card className="h-full flex flex-col" aria-label="Apuestas activas">
+      <h2 className="mb-2 text-lg">Apuestas activas</h2>
+      <div className="flex-1 overflow-y-auto space-y-2">
+        {loading ? (
+          Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full" />
+          ))
+        ) : bets.length === 0 ? (
+          <p className="text-sm text-gray-400">Sin apuestas</p>
+        ) : (
+          bets.map((b) => (
+            <div key={b.id} className="flex justify-between text-sm">
+              <span>{formatMoney(b.amount)}</span>
+              <span>{formatMultiplier(b.cashout)}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/BetForm.tsx
+++ b/frontend/src/components/BetForm.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import Card from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import Tooltip from "@/components/ui/tooltip";
+import { useToast } from "@/components/ui/toast";
+import { formatMoney } from "@/lib/utils";
+
+interface BetFormProps {
+  balance: number;
+  onBet: (newBalance: number) => void;
+}
+
+export default function BetForm({ balance, onBet }: BetFormProps) {
+  const [amount, setAmount] = React.useState(0);
+  const [cashout, setCashout] = React.useState<number | "">("");
+  const toast = useToast();
+
+  const insufficient = amount > balance;
+
+  const placeBet = () => {
+    if (insufficient) {
+      toast("Saldo insuficiente");
+      return;
+    }
+    onBet(balance - amount);
+    toast(`Apuesta de ${formatMoney(amount)} realizada`);
+  };
+
+  return (
+    <Card className="space-y-4" aria-label="Formulario de apuesta">
+      <div className="flex items-center gap-2">
+        <Input
+          aria-label="Monto"
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(Number(e.target.value))}
+          className="w-full"
+        />
+        <Tooltip content="Mitad">
+          <Button aria-label="Mitad" onClick={() => setAmount(amount / 2)}>1/2</Button>
+        </Tooltip>
+        <Tooltip content="Doble">
+          <Button aria-label="Doble" onClick={() => setAmount(amount * 2)}>2x</Button>
+        </Tooltip>
+      </div>
+      <Input
+        aria-label="Cashout"
+        type="number"
+        value={cashout}
+        onChange={(e) => setCashout(e.target.value ? Number(e.target.value) : "")}
+        placeholder="Cashout"
+        className="w-full"
+      />
+      <Button
+        aria-label="Bet"
+        className="w-full bg-neon-blue text-gray-900"
+        onClick={placeBet}
+        disabled={insufficient}
+      >
+        Bet
+      </Button>
+    </Card>
+  );
+}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "bg-gray-700 animate-pulse rounded-md",
+        className
+      )}
+      aria-hidden="true"
+    />
+  );
+}
+
+export default Skeleton;

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface TooltipProps {
+  content: string;
+  children: React.ReactNode;
+}
+
+export function Tooltip({ content, children }: TooltipProps) {
+  return (
+    <div className="relative group inline-block">
+      {children}
+      <div
+        role="tooltip"
+        className={cn(
+          "absolute left-1/2 -translate-x-1/2 top-full mt-2 hidden group-hover:block bg-gray-800 text-xs text-gray-100 px-2 py-1 rounded shadow-lg z-10"
+        )}
+      >
+        {content}
+      </div>
+    </div>
+  );
+}
+
+export default Tooltip;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,5 +4,5 @@
 
 body {
   @apply bg-gray-900 text-gray-100;
-  font-family: 'Inter', sans-serif;
+  font-family: 'Inter Tight', sans-serif;
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,3 +1,11 @@
 export function cn(...classes: (string | undefined | false | null)[]) {
   return classes.filter(Boolean).join(" ");
 }
+
+export function formatMoney(n: number) {
+  return `$${n.toFixed(2)}`;
+}
+
+export function formatMultiplier(x: number) {
+  return `${x.toFixed(2)}x`;
+}

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -1,27 +1,64 @@
-import Navbar from "@/components/Navbar";
-import LastRoundsStrip from "@/components/LastRoundsStrip";
-import GameCanvas from "@/components/GameCanvas";
-import BetPanel from "@/components/BetPanel";
-import { useAuth } from "@/store/auth";
+import * as React from "react";
+import Card from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import Skeleton from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/toast";
+import { formatMoney, formatMultiplier } from "@/lib/utils";
+import BetForm from "@/components/BetForm";
+import ActiveBetsPanel from "@/components/ActiveBetsPanel";
 
 export default function Play() {
-  const balance = useAuth((s) => s.balance);
+  const [balance, setBalance] = React.useState<number | null>(null);
+  const [multiplier, setMultiplier] = React.useState(1);
+  const toast = useToast();
+
+  React.useEffect(() => {
+    fetch("/api/wallet/balance")
+      .then((res) => res.json())
+      .then((data) => setBalance(data.balance ?? 0))
+      .catch(() => toast("Error cargando saldo"));
+  }, [toast]);
+
+  React.useEffect(() => {
+    const id = setInterval(() => {
+      setMultiplier((m) => Number((m + 0.01).toFixed(2)));
+    }, 100);
+    return () => clearInterval(id);
+  }, []);
+
   return (
-    <div className="min-h-screen flex flex-col">
-      <Navbar />
-      <div className="flex-1 p-4 grid gap-4 md:grid-cols-3">
-        <div className="space-y-4">
-          <LastRoundsStrip />
-          <div className="p-4 bg-gray-800 rounded">Saldo: {balance.toFixed(2)}</div>
+    <div className="min-h-screen bg-gray-900 text-gray-100 font-inter">
+      <header className="flex items-center justify-between p-4 border-b border-gray-800">
+        <div className="text-neon-pink font-bold" aria-label="Logo">
+          NeonCrash
         </div>
-        <div className="space-y-4">
-          <GameCanvas />
-          <BetPanel />
+        {balance === null ? (
+          <Skeleton className="h-6 w-24" />
+        ) : (
+          <Badge className="bg-gray-800 border border-neon-blue text-neon-blue">
+            {formatMoney(balance)}
+          </Badge>
+        )}
+      </header>
+      <main className="p-4 grid grid-cols-1 md:grid-cols-12 gap-4">
+        <div className="md:col-span-8 space-y-4">
+          <Card className="flex flex-col items-center justify-center h-64 space-y-4 shadow-md" aria-label="Multiplicador">
+            <div className="text-6xl font-bold text-neon-green transition-all duration-300">
+              {formatMultiplier(multiplier)}
+            </div>
+            <div className="w-full bg-gray-700 h-2 rounded">
+              <div
+                className="bg-neon-pink h-2 rounded"
+                style={{ width: `${(multiplier % 1) * 100}%`, transition: "width 0.1s linear" }}
+              />
+            </div>
+          </Card>
+          {balance !== null && <BetForm balance={balance} onBet={setBalance} />}
         </div>
-        <div className="space-y-4">
-          <div className="p-4 bg-gray-800 rounded">Apuestas activas</div>
+        <div className="md:col-span-4">
+          <ActiveBetsPanel />
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -3,6 +3,9 @@ module.exports = {
   content: ["./frontend/index.html", "./frontend/src/**/*.{ts,tsx}"] ,
   theme: {
     extend: {
+      fontFamily: {
+        inter: ["'Inter Tight'", "sans-serif"],
+      },
       colors: {
         neon: {
           green: "#39ff14",


### PR DESCRIPTION
## Summary
- use Inter Tight font and neon theme styles
- add reusable skeleton, tooltip, bet form and active bets panel
- rebuild play page with balance fetch, animated multiplier and responsive layout

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68abd94a80cc8328b96a249284ec8e61