### PR TITLE
fix: stabilize toast function

### DIFF
--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -11,11 +11,11 @@ export const useToast = () => React.useContext(ToastContext);
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = React.useState<Toast[]>([]);
 
-  const add = (title: string) => {
+  const add = React.useCallback((title: string) => {
     const id = Date.now();
     setToasts((t) => [...t, { id, title }]);
     setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 3000);
-  };
+  }, []);
 
   return (
     <ToastContext.Provider value={add}>


### PR DESCRIPTION
## Summary
- use `useCallback` for toast handler to prevent re-renders from triggering repeated error toasts

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abdb35cf6483289000c159e7be139d