### PR TITLE
feat: add cookie-based admin auth with secure headers

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -16,6 +16,7 @@ from sqlalchemy import text
 from .db import SessionLocal
 
 from .middleware.ratelimit import RateLimitMiddleware
+from .middleware.security_headers import SecureHeadersMiddleware
 from .auth import router as auth_router
 from .admin_routes import router as admin_router
 
@@ -62,6 +63,7 @@ app.add_middleware(
 
 # (después) tus middlewares propios
 app.add_middleware(RateLimitMiddleware)
+app.add_middleware(SecureHeadersMiddleware)
 
 app.mount("/admin", StaticFiles(directory=Path(__file__).parent / "static" / "admin", html=True), name="admin")
 

--- a/backend/api/middleware/security_headers.py
+++ b/backend/api/middleware/security_headers.py
@@ -1,0 +1,19 @@
+"""Middleware that adds common security headers."""
+
+from __future__ import annotations
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class SecureHeadersMiddleware(BaseHTTPMiddleware):
+    """Add a set of security related headers to every response."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        response = await call_next(request)
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        response.headers.setdefault("Permissions-Policy", "geolocation=()")
+        return response
+

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -1,24 +1,37 @@
-import os, jwt
-from fastapi import HTTPException, Depends
-from fastapi.security import OAuth2PasswordBearer
+"""Security helpers for authentication and role-based access control.
+
+This module provides utilities to create and validate JWT tokens stored in
+HTTP-only cookies as well as FastAPI dependencies to enforce RBAC (Role Based
+Access Control).
+"""
+
+from __future__ import annotations
+
+import os
 from datetime import datetime, timedelta
-from pydantic import BaseModel
+from typing import Callable
+
+import jwt
+from fastapi import Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from .db import get_session
 from .models import User
 
+# ---------------------------------------------------------------------------
+# JWT handling
+# ---------------------------------------------------------------------------
+
 JWT_SECRET = os.getenv("JWT_SECRET", "changeme")
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/admin/login")
-
-
-class TokenData(BaseModel):
-    sub: str
-    exp: int
-    is_admin: bool
 
 
 def create_token(user: User) -> str:
+    """Create a short lived access token for *user*.
+
+    The token encodes the user id and whether the user is an admin. Tokens are
+    valid for 8 hours.
+    """
+
     payload = {
         "sub": user.id,
         "is_admin": user.is_admin,
@@ -27,12 +40,57 @@ def create_token(user: User) -> str:
     return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
 
 
-def get_current_admin(token: str = Depends(oauth2_scheme), db: Session = Depends(get_session)) -> User:
+def _decode_token(token: str) -> dict:
     try:
-        data = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
-    except jwt.PyJWTError:
-        raise HTTPException(status_code=401, detail="Token inválido")
+        return jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+    except jwt.PyJWTError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=401, detail="Token inválido") from exc
+
+
+# ---------------------------------------------------------------------------
+# Authentication dependencies
+# ---------------------------------------------------------------------------
+
+def get_current_user(request: Request, db: Session = Depends(get_session)) -> User:
+    """Return the user associated with the request.
+
+    The token is read from the ``Authorization`` header if present or from the
+    ``access_token`` cookie. An ``HTTPException`` is raised if the token is
+    missing or invalid.
+    """
+
+    token: str | None = None
+    auth = request.headers.get("Authorization")
+    if auth and auth.startswith("Bearer "):
+        token = auth.split(" ", 1)[1]
+    if not token:
+        token = request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(status_code=401, detail="No autorizado")
+
+    data = _decode_token(token)
     user = db.get(User, data.get("sub"))
-    if not user or not data.get("is_admin") or not user.is_admin:
-        raise HTTPException(status_code=403, detail="No autorizado")
+    if not user:
+        raise HTTPException(status_code=401, detail="Usuario no encontrado")
     return user
+
+
+def require_roles(*roles: str) -> Callable[[User], User]:
+    """Return a dependency that ensures the current user has one of *roles*.
+
+    Roles are currently derived from ``User.is_admin``. Any role other than
+    ``"admin"`` is considered ``"user"``.
+    """
+
+    def dependency(user: User = Depends(get_current_user)) -> User:
+        role = "admin" if user.is_admin else "user"
+        if role not in roles:
+            raise HTTPException(status_code=403, detail="No autorizado")
+        return user
+
+    return dependency
+
+
+# Convenience dependency for admin-only routes
+get_current_admin = require_roles("admin")
+

--- a/backend/api/static/admin/index.html
+++ b/backend/api/static/admin/index.html
@@ -54,7 +54,6 @@
 
 <script>
   const API = location.origin + "/api/admin";
-  let token = localStorage.getItem("adm_token") || "";
 
   const el = (id)=>document.getElementById(id);
   const setStatus = (t)=> el("status").textContent = t;
@@ -64,21 +63,25 @@
     el("app").style.display = auth ? "block" : "none";
     setStatus(auth ? "Autenticado" : "Desconectado");
   }
-  showApp(!!token);
+  showApp(false);
 
   el("btnLogin")?.addEventListener("click", async ()=>{
     const email = el("email").value.trim();
     const password = el("password").value;
-    const r = await fetch(API+"/login",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({email,password})});
+    const r = await fetch(API+"/login",{
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      body:JSON.stringify({email,password}),
+      credentials:"include"
+    });
     if(!r.ok){ alert("Login inválido"); return; }
-    const data = await r.json();
-    token = data.access_token; localStorage.setItem("adm_token", token);
     showApp(true); loadPending();
   });
 
   async function loadPending(){
-    const r = await fetch(API+"/transactions/pending",{headers:{Authorization:"Bearer "+token}});
-    if(!r.ok){ if(r.status===401||r.status===403){ localStorage.removeItem("adm_token"); token=""; showApp(false); } return; }
+    const r = await fetch(API+"/transactions/pending",{credentials:"include"});
+    if(!r.ok){ if(r.status===401||r.status===403){ showApp(false); } return; }
+    showApp(true);
     const rows = await r.json();
     const tbody = el("tbl").querySelector("tbody");
     tbody.innerHTML = "";
@@ -107,8 +110,9 @@
     const note = approve ? "ok" : prompt("Motivo de rechazo (opcional)") || null;
     const r = await fetch(API+`/transactions/${id}/decide`,{
       method:"POST",
-      headers:{"Content-Type":"application/json", Authorization:"Bearer "+token},
-      body: JSON.stringify({approve, note})
+      headers:{"Content-Type":"application/json"},
+      body: JSON.stringify({approve, note}),
+      credentials:"include"
     });
     if(!r.ok){ alert("Error al decidir"); return; }
     loadPending();
@@ -120,12 +124,13 @@
     if(!email_or_user_id || !(amount>0)) return alert("Completa usuario y monto");
     const r = await fetch(API+"/credit",{
       method:"POST",
-      headers:{"Content-Type":"application/json", Authorization:"Bearer "+token},
-      body: JSON.stringify({email_or_user_id, amount, note:"Ajuste manual"})
+      headers:{"Content-Type":"application/json"},
+      body: JSON.stringify({email_or_user_id, amount, note:"Ajuste manual"}),
+      credentials:"include"
     });
     if(!r.ok){ alert("No se pudo acreditar"); return; }
     el("creditAmount").value=""; alert("Acreditado ✔");
   });
 
-  if(token) loadPending();
+  loadPending();
 </script>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -58,7 +58,8 @@ def test_list_users():
     admin = _create_user("admin@example.com", is_admin=True)
     _create_user("alice@example.com", balance=Decimal("5"))
     token = security.create_token(admin)
-    resp = client.get("/api/admin/users", headers={"Authorization": f"Bearer {token}"})
+    client.cookies.set("access_token", token)
+    resp = client.get("/api/admin/users")
     assert resp.status_code == 200
     users = resp.json()
     assert any(u["email"] == "alice@example.com" and float(u["balance"]) == 5 for u in users)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -57,3 +57,9 @@ def test_rate_limit_block():
             "/api/auth/login", json={"email": "b@b.com", "password": "secret"}
         )
         assert res.status_code == 429
+
+
+def test_secure_headers():
+    with create_client("60") as client:
+        res = client.get("/health")
+        assert res.headers["X-Frame-Options"] == "DENY"


### PR DESCRIPTION
## Summary
- store admin auth token in HttpOnly cookies and enforce RBAC
- add security headers middleware and adjust admin panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac71be39608328b52b5b303fe7a09c