### PR TITLE
Add game HUD and action UI with custom plane icon

### DIFF
--- a/frontend/src/components/GameActionBar.tsx
+++ b/frontend/src/components/GameActionBar.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import GameActionButton from "@/components/GameActionButton";
+
+interface GameActionBarProps {
+  onSubmit: (value: string) => void;
+}
+
+export default function GameActionBar({ onSubmit }: GameActionBarProps) {
+  const [value, setValue] = React.useState("");
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!value.trim()) return;
+    onSubmit(value);
+    setValue("");
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex items-center gap-2 p-2 bg-white/60 backdrop-blur-md rounded-2xl shadow-sm"
+    >
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Comando / destino / acción…"
+        className="flex-1 bg-transparent px-4 py-2 text-gray-900 placeholder-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded-2xl"
+      />
+      <GameActionButton aria-label="Enviar comando" type="submit" />
+    </form>
+  );
+}

--- a/frontend/src/components/GameActionButton.tsx
+++ b/frontend/src/components/GameActionButton.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { motion } from "framer-motion";
+import PlaneDuotone from "@/components/icons/PlaneDuotone";
+import { cn } from "@/lib/utils";
+
+interface GameActionButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  loading?: boolean;
+}
+
+export default function GameActionButton({
+  loading,
+  disabled,
+  className,
+  ...props
+}: GameActionButtonProps) {
+  const isDisabled = disabled || loading;
+  return (
+    <motion.button
+      whileHover={!isDisabled ? { scale: 1.05 } : undefined}
+      whileTap={!isDisabled ? { scale: 0.95 } : undefined}
+      transition={{ type: "spring", stiffness: 400, damping: 20 }}
+      className={cn(
+        "relative inline-flex items-center justify-center rounded-2xl px-4 py-2 text-white bg-gradient-to-r from-indigo-500 to-violet-500 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-400 disabled:opacity-50 disabled:cursor-not-allowed", 
+        className
+      )}
+      aria-label={props["aria-label"] || "Acción"}
+      disabled={isDisabled}
+      {...props}
+    >
+      {loading ? (
+        <svg
+          className="h-5 w-5 animate-spin text-white"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 00-12 12h4z"
+          />
+        </svg>
+      ) : (
+        <PlaneDuotone className="h-5 w-5" />
+      )}
+    </motion.button>
+  );
+}

--- a/frontend/src/components/GameHUD.tsx
+++ b/frontend/src/components/GameHUD.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+interface GameHUDProps {
+  title: string;
+  ping: number;
+  credits: number;
+}
+
+export default function GameHUD({ title, ping, credits }: GameHUDProps) {
+  return (
+    <div className="flex items-center justify-between p-2 bg-white/60 backdrop-blur-md rounded-2xl shadow-sm">
+      <div className="flex items-center gap-2">
+        <div className="h-10 w-10 rounded-lg bg-gradient-to-br from-indigo-500 to-violet-500" />
+        <div>
+          <h1 className="text-lg font-semibold leading-none">{title}</h1>
+          <p className="text-xs text-gray-600">Sector 7 — Online</p>
+        </div>
+      </div>
+      <div className="flex items-center gap-8 text-sm">
+        <div className="flex items-center gap-1">
+          <span className="text-gray-500">Ping</span>
+          <span className="font-medium">{ping}ms</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-gray-500">Créditos</span>
+          <span className="font-medium">{credits}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/icons/PlaneDuotone.tsx
+++ b/frontend/src/components/icons/PlaneDuotone.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+export default function PlaneDuotone(
+  props: React.SVGProps<SVGSVGElement>
+) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      stroke="none"
+      {...props}
+    >
+      <path
+        d="M2 12l9 3 1 7 2-6 8-1 2-3-12-9z"
+        fill="currentColor"
+        opacity="0.4"
+      />
+      <path
+        d="M2 12l21-7-7 9 7 3-8 1-2 6-3-7z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/pages/UIDemo.tsx
+++ b/frontend/src/pages/UIDemo.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import GameHUD from "@/components/GameHUD";
+import GameActionBar from "@/components/GameActionBar";
+
+export default function UIDemo() {
+  const handleSubmit = (value: string) => {
+    console.log("Comando:", value);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col gap-8 p-4 font-inter">
+      <GameHUD title="Galaxy Run" ping={18} credits={1200} />
+      <div className="flex-1 flex items-center justify-center rounded-2xl bg-gray-100 shadow-inner">
+        Aquí va la escena del juego
+      </div>
+      <GameActionBar onSubmit={handleSubmit} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add handcrafted PlaneDuotone SVG icon
- create GameActionButton with hover/tap/disabled/loading states
- add GameActionBar and GameHUD components
- include UIDemo page wiring HUD and action bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac73849c8c83288bef744eb67537b1