### PR TITLE
fix: pin bcrypt to avoid passlib __about__ error

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.30.6
 SQLAlchemy==2.0.32
 psycopg[binary]>=3.2.2,<3.3
 passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 python-jose[cryptography]==3.3.0
 python-dotenv==1.0.1
 pydantic-settings==2.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.30.6
 SQLAlchemy==2.0.32
 psycopg[binary]>=3.2.2,<3.3
 passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 python-jose[cryptography]==3.3.0
 python-dotenv==1.0.1
 pydantic-settings==2.5.2


### PR DESCRIPTION
## Summary
- pin bcrypt to 4.0.1 for compatibility with passlib

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8897d8e08328b9ca85665a4e17d5