### PR TITLE
Add placeholder active bets endpoint and handle UI errors

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -26,8 +26,16 @@ crash: Optional[ModuleType] = None
 me: Optional[ModuleType] = None
 metrics: Optional[ModuleType] = None
 leaderboard: Optional[ModuleType] = None
+bets: Optional[ModuleType] = None
 try:
-    from .routers import wallet as wallet, crash as crash, me as me, metrics as metrics, leaderboard as leaderboard  # type: ignore
+    from .routers import (
+        wallet as wallet,
+        crash as crash,
+        me as me,
+        metrics as metrics,
+        leaderboard as leaderboard,
+        bets as bets,
+    )  # type: ignore
 except Exception:
     pass
 
@@ -135,6 +143,8 @@ if metrics:
     app.include_router(metrics.router, tags=["default"])
 if leaderboard:
     app.include_router(leaderboard.router, tags=["leaderboard"])
+if bets:
+    app.include_router(bets.router, tags=["bets"])
 
 # Auth router
 app.include_router(auth_router)

--- a/backend/api/routers/bets.py
+++ b/backend/api/routers/bets.py
@@ -1,0 +1,29 @@
+"""Routers for bet-related endpoints.
+
+Currently this project does not keep track of active bets, but the
+frontend expects an endpoint to retrieve them.  To avoid 404 responses
+and subsequent runtime errors in the UI, this router exposes
+``GET /bets/active`` which simply returns an empty list for the
+authenticated user.
+"""
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from ..auth import get_current_user
+from ..models import User
+
+router = APIRouter(prefix="/bets")
+
+
+@router.get("/active")
+def list_active_bets(user: User = Depends(get_current_user)) -> list[dict[str, Any]]:
+    """Return active bets for the authenticated user.
+
+    Active bet tracking is not yet implemented, so this currently returns an
+    empty list.
+    """
+
+    return []
+

--- a/backend/seed_admin.py
+++ b/backend/seed_admin.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from passlib.hash import bcrypt
 
-from api.models import Base, User, Wallet
+from api.models import User, Wallet
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 engine = create_engine(DATABASE_URL, future=True)
@@ -14,8 +14,14 @@ def ensure_admin(email: str, password: str, username: str = "admin"):
     with Session() as db:
         user = db.query(User).filter(User.email == email.lower()).first()
         if not user:
-            user = User(email=email.lower(), username=username, password_hash=bcrypt.hash(password), is_admin=True)
-            db.add(user); db.flush()
+            user = User(
+                email=email.lower(),
+                username=username,
+                password_hash=bcrypt.hash(password),
+                is_admin=True,
+            )
+            db.add(user)
+            db.flush()
             db.add(Wallet(user_id=user.id, balance=0))
         else:
             user.is_admin = True

--- a/frontend/src/components/ActiveBetsPanel.tsx
+++ b/frontend/src/components/ActiveBetsPanel.tsx
@@ -18,9 +18,17 @@ export default function ActiveBetsPanel() {
 
   React.useEffect(() => {
     fetch(`${API_URL}/bets/active`, { credentials: "include" })
-      .then((res) => res.json())
-      .then((data) => setBets(data))
-      .catch(() => toast("Error cargando apuestas"))
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error("failed");
+        }
+        return res.json();
+      })
+      .then((data) => setBets(Array.isArray(data) ? data : []))
+      .catch(() => {
+        toast("Error cargando apuestas");
+        setBets([]);
+      })
       .finally(() => setLoading(false));
   }, [toast]);
 

--- a/tests/test_bets.py
+++ b/tests/test_bets.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+# Ensure project backend on path and set dummy DATABASE_URL before importing app
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "backend"))
+os.environ["DATABASE_URL"] = "postgresql+psycopg://user:pass@localhost/test"
+os.environ["RATE_LIMIT_PER_MIN"] = "1000"
+
+import api.main as main  # noqa: E402
+from api.models import Base  # noqa: E402
+import api.db as db  # noqa: E402
+import api.auth as auth  # noqa: E402
+
+
+test_engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+db.engine = test_engine
+auth.engine = test_engine
+db.SessionLocal.configure(bind=test_engine)
+Base.metadata.drop_all(db.engine)
+Base.metadata.create_all(db.engine)
+
+client = TestClient(main.app)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db():
+    Base.metadata.drop_all(db.engine)
+    Base.metadata.create_all(db.engine)
+    yield
+
+
+def _auth_header(token: str):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register_user(email: str = "a@example.com", password: str = "secret"):
+    resp = client.post(
+        "/api/auth/register",
+        json={"email": email, "username": "user", "password": password},
+    )
+    assert resp.status_code == 201
+    resp_login = client.post(
+        "/api/auth/login", json={"email": email, "password": password}
+    )
+    assert resp_login.status_code == 200
+    return resp_login.json()["token"]
+
+
+def test_active_bets_empty():
+    token = _register_user()
+    headers = _auth_header(token)
+    r = client.get("/bets/active", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == []
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -15,11 +15,11 @@ sys.path.append(str(ROOT / "backend"))
 os.environ["DATABASE_URL"] = "postgresql+psycopg://user:pass@localhost/test"
 os.environ["RATE_LIMIT_PER_MIN"] = "1000"
 
-import api.main as main
-from api.models import Base
-import api.db as db
-import api.routers.crash as crash_router
-import api.routers.metrics as metrics_router
+import api.main as main  # noqa: E402
+from api.models import Base  # noqa: E402
+import api.db as db  # noqa: E402
+import api.routers.crash as crash_router  # noqa: E402
+import api.routers.metrics as metrics_router  # noqa: E402
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -13,7 +13,7 @@ os.environ.setdefault("RNG_HOUSE_EDGE", "0.01")
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT / "backend"))
 
-from api.services.rng import SEEDS, app, hmac_sha256, verify_signature
+from api.services.rng import SEEDS, app, hmac_sha256, verify_signature  # noqa: E402
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- add `/bets/active` API route returning an empty list to satisfy frontend
- wire bets router into API and add test coverage
- handle fetch errors in ActiveBetsPanel to avoid runtime type errors

## Testing
- `ruff check backend tests`
- `mypy --ignore-missing-imports backend` *(fails: Invalid annotations and attribute errors in existing files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a6c30bc8328ba9e1e95f6b7ddf7