### PR TITLE
feat: add crash game engine

### DIFF
--- a/backend/api/crash/engine.py
+++ b/backend/api/crash/engine.py
@@ -1,0 +1,125 @@
+import asyncio, math, os, time, uuid, random
+from typing import Dict, Optional, Set
+from fastapi import WebSocket
+
+CRASH_MIN_BET = float(os.getenv("CRASH_MIN_BET", "1"))
+CRASH_TICK_MS = int(os.getenv("CRASH_TICK_MS", "100"))
+CRASH_GROWTH_RATE = float(os.getenv("CRASH_GROWTH_RATE", "0.06"))
+CRASH_INTERMISSION_SECONDS = float(os.getenv("CRASH_INTERMISSION_SECONDS", "4"))
+
+class CrashEngine:
+    def __init__(self) -> None:
+        self.phase: str = "BETTING"  # BETTING | RUNNING | CRASHED
+        self.round_id: str = str(uuid.uuid4())
+        self.multiplier: float = 1.0
+        self.crash_at: Optional[float] = None
+        self.started: bool = False  # si ya arrancó la ronda actual
+        self.bets: Dict[str, Dict] = {}  # player_id -> {amount, cashed:bool, payout:Optional[float]}
+        self.connections: Set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+        self._runner_task: Optional[asyncio.Task] = None
+
+    # --------- utilidades ----------
+    def _gen_crash_at(self) -> float:
+        # cola pesada simple (exponencial) + pequeños límites
+        u = random.random()
+        base = 1 + (-math.log(max(1e-9, 1 - u)))
+        return round(max(1.01, base), 2)
+
+    async def _broadcast(self, msg: dict) -> None:
+        dead = []
+        for ws in list(self.connections):
+            try:
+                await ws.send_json(msg)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            self.connections.discard(ws)
+
+    # --------- API pública ----------
+    async def subscribe(self, ws: WebSocket):
+        await ws.accept()
+        self.connections.add(ws)
+        # estado inicial compacto
+        await ws.send_json({"t": "state", "phase": self.phase, "m": self.multiplier, "rid": self.round_id})
+
+    async def place_bet(self, player_id: str, amount: float, auto: Optional[float] = None):
+        if amount < CRASH_MIN_BET:
+            raise ValueError("MIN_BET")
+        async with self._lock:
+            if self.phase != "BETTING":
+                raise RuntimeError("NOT_BETTING")
+            if player_id in self.bets:
+                raise RuntimeError("ALREADY_BET")
+            self.bets[player_id] = {"amount": float(amount), "auto": auto, "cashed": False, "payout": None}
+            await self._broadcast({"t": "player_bet", "a": amount})
+            # si es la primera apuesta de la ronda, arrancamos
+            if not self.started:
+                self.started = True
+                self.crash_at = self._gen_crash_at()
+                self.phase = "RUNNING"
+                self.multiplier = 1.0
+                if self._runner_task is None or self._runner_task.done():
+                    self._runner_task = asyncio.create_task(self._run_loop())
+
+    async def cashout(self, player_id: str):
+        async with self._lock:
+            if self.phase != "RUNNING":
+                raise RuntimeError("NOT_RUNNING")
+            bet = self.bets.get(player_id)
+            if not bet or bet["cashed"]:
+                raise RuntimeError("NO_ACTIVE_BET")
+            bet["cashed"] = True
+            bet["payout"] = round(bet["amount"] * self.multiplier, 2)
+            await self._broadcast({"t": "player_cash", "at": self.multiplier, "p": bet["payout"]})
+            return {"at": self.multiplier, "payout": bet["payout"]}
+
+    async def state(self, player_id: Optional[str] = None):
+        you = None
+        if player_id and player_id in self.bets:
+            b = self.bets[player_id]
+            you = {"amount": b["amount"], "cashed": b["cashed"], "payout": b["payout"], "auto": b["auto"]}
+        return {
+            "round_id": self.round_id,
+            "phase": self.phase,
+            "multiplier": self.multiplier,
+            "your_bet": you,
+            "min_bet": CRASH_MIN_BET,
+        }
+
+    # --------- loop de ejecución ----------
+    async def _run_loop(self):
+        # corre hasta crash; luego CRASHED un rato; luego reset a BETTING
+        t0 = time.perf_counter()
+        await self._broadcast({"t": "start", "rid": self.round_id, "at": self.crash_at})
+        try:
+            while True:
+                await asyncio.sleep(CRASH_TICK_MS / 1000.0)
+                # crecimiento exponencial suave
+                self.multiplier = round(math.exp(CRASH_GROWTH_RATE * (time.perf_counter() - t0)), 2)
+                await self._broadcast({"t": "tick", "m": self.multiplier})
+                # auto cashout
+                for pid, b in list(self.bets.items()):
+                    if not b["cashed"] and b["auto"] and self.multiplier >= float(b["auto"]):
+                        b["cashed"] = True
+                        b["payout"] = round(b["amount"] * self.multiplier, 2)
+                        await self._broadcast({"t": "player_cash", "at": self.multiplier, "p": b["payout"]})
+                if self.crash_at and self.multiplier >= self.crash_at:
+                    break
+        finally:
+            # CRASH!
+            self.phase = "CRASHED"
+            await self._broadcast({"t": "crash", "at": self.crash_at})
+            # liquidar perdedores (sin cashout)
+            for pid, b in self.bets.items():
+                if not b["cashed"]:
+                    b["payout"] = 0.0
+            await asyncio.sleep(CRASH_INTERMISSION_SECONDS)
+            # reset
+            self.phase = "BETTING"
+            self.round_id = str(uuid.uuid4())
+            self.multiplier = 1.0
+            self.crash_at = None
+            self.started = False
+            self.bets.clear()
+            await self._broadcast({"t": "betting", "rid": self.round_id})

--- a/backend/api/crash/router.py
+++ b/backend/api/crash/router.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, WebSocket
+from .engine import CrashEngine, CRASH_MIN_BET
+import uuid
+
+router = APIRouter(prefix="/crash", tags=["crash"])
+
+def get_engine() -> CrashEngine:
+    # Asumimos engine en app.state (configurado en main.py)
+    from api.main import app
+    return app.state.crash_engine  # type: ignore
+
+def ensure_player_id(player_id: str | None, response: Response) -> str:
+    if player_id:
+        return player_id
+    pid = str(uuid.uuid4())
+    # cookie simple; si tu auth usa cookies httpOnly, podés migrar esto a esa identidad
+    response.set_cookie("player_id", pid, httponly=False, samesite="Lax")
+    return pid
+
+@router.get("/state")
+async def state(response: Response, player_id: str | None = Cookie(default=None), engine: CrashEngine = Depends(get_engine)):
+    pid = ensure_player_id(player_id, response)
+    return await engine.state(pid)
+
+@router.post("/bet")
+async def bet(
+    response: Response,
+    amount: float,
+    auto_cashout: float | None = None,
+    player_id: str | None = Cookie(default=None),
+    engine: CrashEngine = Depends(get_engine),
+):
+    pid = ensure_player_id(player_id, response)
+    try:
+        await engine.place_bet(pid, float(amount), auto_cashout)
+        return {"ok": True}
+    except ValueError as e:
+        if str(e) == "MIN_BET":
+            raise HTTPException(status_code=422, detail=f"amount must be >= {CRASH_MIN_BET}")
+        raise
+    except RuntimeError as e:
+        code = 409 if str(e) in {"NOT_BETTING", "ALREADY_BET"} else 400
+        raise HTTPException(status_code=code, detail=str(e))
+
+@router.post("/cashout")
+async def cashout(
+    response: Response,
+    player_id: str | None = Cookie(default=None),
+    engine: CrashEngine = Depends(get_engine),
+):
+    pid = ensure_player_id(player_id, response)
+    try:
+        return await engine.cashout(pid)
+    except RuntimeError as e:
+        code = 409 if str(e) in {"NOT_RUNNING", "NO_ACTIVE_BET"} else 400
+        raise HTTPException(status_code=code, detail=str(e))
+
+@router.websocket("/stream")
+async def stream(ws: WebSocket, engine: CrashEngine = Depends(get_engine)):
+    await engine.subscribe(ws)
+    try:
+        while True:
+            # Sólo mantenemos viva la conexión; el engine hace broadcast
+            await ws.receive_text()
+    except Exception:
+        pass

--- a/frontend/src/hooks/useCrashData.ts
+++ b/frontend/src/hooks/useCrashData.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from "react";
+import { API_URL, WS_URL } from "@/lib/env";
+
+type Phase = "BETTING" | "RUNNING" | "CRASHED";
+export function useCrashData() {
+  const [phase, setPhase] = useState<Phase>("BETTING");
+  const [multiplier, setMultiplier] = useState(1);
+  const [minBet, setMinBet] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  // Carga inicial
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`${API_URL}/crash/state`, { credentials: "include" });
+        const d = await r.json();
+        if (d.phase) setPhase(d.phase);
+        if (d.multiplier) setMultiplier(d.multiplier);
+        if (d.min_bet) setMinBet(d.min_bet);
+      } catch (e: any) {
+        setError(e?.message ?? "Error inicial");
+      }
+    })();
+  }, []);
+
+  // WS
+  useEffect(() => {
+    const ws = new WebSocket(`${WS_URL}/crash/stream`);
+    wsRef.current = ws;
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg.t === "state") {
+          if (msg.phase) setPhase(msg.phase);
+          if (msg.m) setMultiplier(msg.m);
+        } else if (msg.t === "tick") {
+          setPhase("RUNNING");
+          setMultiplier(msg.m);
+        } else if (msg.t === "start") {
+          setPhase("RUNNING");
+          setMultiplier(1);
+        } else if (msg.t === "crash") {
+          setPhase("CRASHED");
+        } else if (msg.t === "betting") {
+          setPhase("BETTING");
+          setMultiplier(1);
+        }
+      } catch {}
+    };
+    ws.onerror = () => setError("WS error");
+    ws.onclose = () => {};
+    return () => ws.close();
+  }, []);
+
+  async function bet(amount: number, auto?: number | null) {
+    const r = await fetch(`${API_URL}/crash/bet?amount=${amount}${auto ? `&auto_cashout=${auto}` : ""}`, {
+      method: "POST",
+      credentials: "include",
+    });
+    if (!r.ok) throw new Error((await r.json()).detail ?? "bet failed");
+  }
+
+  async function cashout() {
+    const r = await fetch(`${API_URL}/crash/cashout`, { method: "POST", credentials: "include" });
+    if (!r.ok) throw new Error((await r.json()).detail ?? "cashout failed");
+    return r.json();
+  }
+
+  return { phase, multiplier, minBet, error, bet, cashout };
+}

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -2,6 +2,3 @@ export const API_URL = import.meta.env.VITE_API_URL as string;
 export const WS_URL =
   (import.meta.env.VITE_WS_URL as string) ??
   (API_URL ? API_URL.replace(/^https?/, (m) => (m === "https" ? "wss" : "ws")) : "");
-if (!API_URL) {
-  console.warn("VITE_API_URL is missing");
-}


### PR DESCRIPTION
## Summary
- add CrashEngine with round management and broadcasting
- expose crash betting endpoints and websocket router
- hook crash engine into FastAPI app and wire new React hook/UI

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac988a81a883289ef862146ad89bbf