### PR TITLE
Include auth token for balance and active bets requests

### DIFF
--- a/frontend/src/components/ActiveBetsPanel.tsx
+++ b/frontend/src/components/ActiveBetsPanel.tsx
@@ -17,7 +17,11 @@ export default function ActiveBetsPanel() {
   const toast = useToast();
 
   React.useEffect(() => {
-    fetch(`${API_URL}/bets/active`, { credentials: "include" })
+    const token = localStorage.getItem("token") || "";
+    fetch(`${API_URL}/bets/active`, {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: "include",
+    })
       .then((res) => {
         if (!res.ok) {
           throw new Error("failed");

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -12,7 +12,11 @@ export default function Play() {
   const toast = useToast();
 
   React.useEffect(() => {
-    fetch(`${API_URL}/wallet/balance`, { credentials: "include" })
+    const token = localStorage.getItem("token") || "";
+    fetch(`${API_URL}/wallet/balance`, {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: "include",
+    })
       .then((res) => res.json())
       .then((data) => setBalance(data.balance ?? 0))
       .catch(() => toast("Error cargando saldo"));


### PR DESCRIPTION
## Summary
- add Authorization header when fetching wallet balance on Play page
- send token with Active Bets panel requests

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb38f6f308328b62e5722f9f50ce2