### PR TITLE
Handle repeated crash cashouts without conflict

### DIFF
--- a/tests/test_crash_smoke.py
+++ b/tests/test_crash_smoke.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
+from api.crash.engine import CrashEngine
 
 # Ensure project backend on path and set dummy DATABASE_URL before importing app
 ROOT = Path(__file__).resolve().parents[1]
@@ -41,6 +42,12 @@ def _fresh_db():
     yield
 
 
+@pytest.fixture(autouse=True)
+def _fresh_engine():
+    main.app.state.crash_engine = CrashEngine()
+    yield
+
+
 def test_bet_amount_zero():
     r = client.post("/crash/bet", json={"amount": 0})
     assert r.status_code == 422
@@ -49,3 +56,23 @@ def test_bet_amount_zero():
 def test_cashout_in_betting_phase():
     r = client.post("/crash/cashout", json={})
     assert r.status_code == 409
+
+
+def test_cashout_is_idempotent():
+    pid = "pid1"
+    engine = main.app.state.crash_engine
+    engine.phase = "RUNNING"
+    engine.multiplier = 2.0
+    engine.bets[pid] = {
+        "amount": 10.0,
+        "auto": None,
+        "cashed": False,
+        "payout": None,
+        "cash_at": None,
+    }
+    r1 = client.post("/crash/cashout", cookies={"player_id": pid})
+    assert r1.status_code == 200
+    data1 = r1.json()
+    r2 = client.post("/crash/cashout", cookies={"player_id": pid})
+    assert r2.status_code == 200
+    assert r2.json() == data1


### PR DESCRIPTION
## Summary
- Track when bets are cashed out and return the stored payout if cashout is requested again
- Cover crash cashout idempotency with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acb58f26088328aa179b1bd3966244