### PR TITLE
Remove numpy requirement from simulation tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 frontend/dist/
+__pycache__/
+*.pyc
+.venv/

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,6 @@ httpx==0.27.2
 email-validator==2.2.0
 alembic==1.13.1
 pytest==8.2.2
-numpy==1.26.4
 prometheus_client==0.20.0
 locust==2.24.0
 PyJWT==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ httpx==0.27.2
 email-validator==2.2.0
 pytest==8.2.2
 alembic==1.13.1
-numpy==1.26.4
 locust==2.24.0
 PyJWT==2.8.0
 aiosqlite==0.20.0


### PR DESCRIPTION
## Summary
- avoid heavy numpy dependency in crash simulator by using pure Python percentile logic
- drop numpy from project requirements and ignore Python cache files

## Testing
- `python -m pytest`
- `ruff check .` *(fails: E402 module level import not at top of file)*
- `mypy --ignore-missing-imports .` *(fails: found 28 errors in 6 files)*
- `python tools/simulate_crash.py -n 1000`

------
https://chatgpt.com/codex/tasks/task_e_68ae1b7f2f888328ae5e844877ee786c