### PR TITLE
Add fade-in animation and refine site styling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import { ToastProvider, useToast } from "./components/ui/toast";
 import { setClientErrorHandler } from "./api/client";
 import AdminApp from "./admin";
+import FadeIn from "./components/FadeIn";
 
 function AppRoutes() {
   const toast = useToast();
@@ -34,7 +35,9 @@ function AppRoutes() {
 export default function App() {
   return (
     <ToastProvider>
-      <AppRoutes />
+      <FadeIn>
+        <AppRoutes />
+      </FadeIn>
     </ToastProvider>
   );
 }

--- a/frontend/src/components/FadeIn.tsx
+++ b/frontend/src/components/FadeIn.tsx
@@ -1,0 +1,15 @@
+import { motion, MotionProps } from "framer-motion";
+import { PropsWithChildren } from "react";
+
+export default function FadeIn({ children, ...props }: PropsWithChildren<MotionProps>) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ export const Button = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttrib
     <button
       ref={ref}
       className={cn(
-        "px-4 py-2 rounded bg-neon-blue text-gray-900 hover:bg-neon-pink transition-colors disabled:opacity-50",
+        "px-4 py-2 rounded bg-neon-blue text-gray-900 hover:bg-neon-pink transition disabled:opacity-50 transform hover:scale-105",
         className
       )}
       {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,6 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gray-900 text-gray-100;
+  @apply bg-gradient-to-b from-gray-900 to-gray-800 text-gray-100;
   font-family: 'Inter Tight', sans-serif;
 }


### PR DESCRIPTION
## Summary
- Introduce reusable `FadeIn` component using framer-motion
- Apply fade-in to app routes and gradient background for richer visuals
- Enhance button hover with scaling for more dynamic interaction

## Testing
- `npm run build`
- `pytest`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2f133ad08328a62ca3555ad3c112