### PR TITLE
Implement crash betting with wallet and persistence

### DIFF
--- a/backend/api/crash/router.py
+++ b/backend/api/crash/router.py
@@ -1,27 +1,28 @@
-import uuid
-from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, WebSocket
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException, WebSocket
 from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..auth import get_current_user
+from .. import db
+from ..models import CrashBet, CrashRound, User
+from ..services.wallet import apply_transaction
 from .engine import CrashEngine, CRASH_MIN_BET
 
 router = APIRouter(prefix="/crash", tags=["crash"])
+
 
 def get_engine() -> CrashEngine:
     # Asumimos engine en app.state (configurado en main.py)
     from api.main import app
     return app.state.crash_engine  # type: ignore
 
-def ensure_player_id(player_id: str | None, response: Response) -> str:
-    if player_id:
-        return player_id
-    pid = str(uuid.uuid4())
-    # cookie simple; si tu auth usa cookies httpOnly, podés migrar esto a esa identidad
-    response.set_cookie("player_id", pid, httponly=False, samesite="Lax")
-    return pid
 
 @router.get("/state")
-async def state(response: Response, player_id: str | None = Cookie(default=None), engine: CrashEngine = Depends(get_engine)):
-    pid = ensure_player_id(player_id, response)
-    return await engine.state(pid)
+async def state(user: User = Depends(get_current_user), engine: CrashEngine = Depends(get_engine)):
+    return await engine.state(user.id)
 
 class BetIn(BaseModel):
     amount: float
@@ -31,14 +32,11 @@ class BetIn(BaseModel):
 @router.post("/bet", status_code=201)
 async def bet(
     body: BetIn,
-    response: Response,
-    player_id: str | None = Cookie(default=None),
     engine: CrashEngine = Depends(get_engine),
+    user: User = Depends(get_current_user),
 ):
-    pid = ensure_player_id(player_id, response)
     try:
-        await engine.place_bet(pid, body.amount, body.auto_cashout)
-        return {"ok": True}
+        await engine.place_bet(user.id, body.amount, body.auto_cashout)
     except ValueError as e:
         if str(e) == "MIN_BET":
             raise HTTPException(status_code=422, detail=f"amount must be >= {CRASH_MIN_BET}")
@@ -47,18 +45,54 @@ async def bet(
         code = 409 if str(e) in {"NOT_BETTING", "ALREADY_BET"} else 400
         raise HTTPException(status_code=code, detail=str(e))
 
+    with Session(db.engine) as s, s.begin():
+        if not s.get(CrashRound, engine.round_id):
+            s.add(CrashRound(id=engine.round_id, crash_at=engine.crash_at or 0.0))
+        apply_transaction(
+            s,
+            user.id,
+            Decimal(str(-body.amount)),
+            "crash_bet",
+            f"crash_bet:{engine.round_id}:{user.id}",
+        )
+        s.add(
+            CrashBet(
+                round_id=engine.round_id,
+                user_id=user.id,
+                amount=Decimal(str(body.amount)),
+            )
+        )
+    return {"ok": True}
+
 @router.post("/cashout")
 async def cashout(
-    response: Response,
-    player_id: str | None = Cookie(default=None),
     engine: CrashEngine = Depends(get_engine),
+    user: User = Depends(get_current_user),
 ):
-    pid = ensure_player_id(player_id, response)
     try:
-        return await engine.cashout(pid)
+        data = await engine.cashout(user.id)
     except RuntimeError as e:
         code = 409 if str(e) in {"NOT_RUNNING", "NO_ACTIVE_BET"} else 400
         raise HTTPException(status_code=code, detail=str(e))
+
+    with Session(db.engine) as s, s.begin():
+        bet = s.execute(
+            select(CrashBet).where(
+                CrashBet.round_id == engine.round_id, CrashBet.user_id == user.id
+            ).with_for_update()
+        ).scalar_one_or_none()
+        if bet and bet.status == "OPEN":
+            bet.status = "CASHED"
+            bet.cashout_multiplier = data["at"]
+            bet.payout = Decimal(str(data["payout"]))
+            apply_transaction(
+                s,
+                user.id,
+                Decimal(str(data["payout"])),
+                "crash_win",
+                f"crash_cashout:{engine.round_id}:{user.id}",
+            )
+    return data
 
 @router.websocket("/stream")
 async def stream(ws: WebSocket, engine: CrashEngine = Depends(get_engine)):
@@ -69,3 +103,18 @@ async def stream(ws: WebSocket, engine: CrashEngine = Depends(get_engine)):
             await ws.receive_text()
     except Exception:
         pass
+
+
+async def handle_crash(round_id: str, losers: list[str]):
+    """Mark losing bets as lost in the database."""
+    if not losers:
+        return
+    with Session(db.engine) as s, s.begin():
+        s.execute(
+            select(CrashBet)  # dummy select to ensure table exists in tests
+        )
+        s.query(CrashBet).filter(
+            CrashBet.round_id == round_id,
+            CrashBet.user_id.in_(losers),
+            CrashBet.status == "OPEN",
+        ).update({"status": "LOST", "payout": Decimal("0")}, synchronize_session=False)

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -20,7 +20,7 @@ from .middleware.security_headers import SecureHeadersMiddleware
 from .auth import router as auth_router
 from .admin_routes import router as admin_router
 from api.crash.engine import CrashEngine
-from api.crash.router import router as crash_router
+from api.crash.router import router as crash_router, handle_crash
 
 
 def _parse_origins(raw: str | None) -> list[str]:
@@ -55,7 +55,9 @@ except Exception:
 ALLOWED_ORIGINS = _parse_origins(os.getenv("ALLOWED_ORIGINS"))
 
 app = FastAPI(title="FastAPI", version="0.1.0")
-app.state.crash_engine = CrashEngine()
+engine = CrashEngine()
+engine.on_crash = handle_crash
+app.state.crash_engine = engine
 
 logger = logging.getLogger("uvicorn")
 logger.info("CORS: %d allowed origins", len(ALLOWED_ORIGINS))

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -118,3 +118,36 @@ class AuditLog(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
+
+
+class CrashRound(Base):
+    """Crash game round metadata."""
+
+    __tablename__ = "crash_rounds"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    crash_at: Mapped[float] = mapped_column(Numeric(10, 2))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class CrashBet(Base):
+    """Individual bets per crash round."""
+
+    __tablename__ = "crash_bets"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True
+    )
+    round_id: Mapped[str] = mapped_column(ForeignKey("crash_rounds.id"), index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(18, 6))
+    status: Mapped[str] = mapped_column(
+        Enum("OPEN", "CASHED", "LOST", name="crash_bet_status"), default="OPEN"
+    )
+    cashout_multiplier: Mapped[Optional[float]] = mapped_column(Numeric(10, 2), nullable=True)
+    payout: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 6), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )

--- a/tests/test_crash_smoke.py
+++ b/tests/test_crash_smoke.py
@@ -1,12 +1,16 @@
 import os
 import sys
 from pathlib import Path
+import time
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.pool import StaticPool
+
 from api.crash.engine import CrashEngine
+import api.crash.router as crash_router
+from api.models import CrashBet, Base
 
 # Ensure project backend on path and set dummy DATABASE_URL before importing app
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,7 +19,6 @@ os.environ["DATABASE_URL"] = "postgresql+psycopg://user:pass@localhost/test"
 os.environ["RATE_LIMIT_PER_MIN"] = "1000"
 
 import api.main as main  # noqa: E402
-from api.models import Base  # noqa: E402
 import api.db as db  # noqa: E402
 import api.auth as auth  # noqa: E402
 
@@ -44,35 +47,82 @@ def _fresh_db():
 
 @pytest.fixture(autouse=True)
 def _fresh_engine():
-    main.app.state.crash_engine = CrashEngine()
+    eng = CrashEngine()
+    eng.on_crash = crash_router.handle_crash
+    main.app.state.crash_engine = eng
     yield
 
 
+def _register_user(email: str = "a@example.com"):
+    resp = client.post(
+        "/api/auth/register",
+        json={"email": email, "username": "user", "password": "secret"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    uid = data["user"]["id"]
+    token = data["token"]
+    return uid, {"Authorization": f"Bearer {token}"}
+
+
 def test_bet_amount_zero():
-    r = client.post("/crash/bet", json={"amount": 0})
+    uid, headers = _register_user()
+    r = client.post("/crash/bet", json={"amount": 0}, headers=headers)
     assert r.status_code == 422
 
 
 def test_cashout_in_betting_phase():
-    r = client.post("/crash/cashout", json={})
+    uid, headers = _register_user("b@example.com")
+    r = client.post("/crash/cashout", headers=headers)
     assert r.status_code == 409
 
 
 def test_cashout_is_idempotent():
-    pid = "pid1"
+    uid, headers = _register_user("c@example.com")
     engine = main.app.state.crash_engine
     engine.phase = "RUNNING"
     engine.multiplier = 2.0
-    engine.bets[pid] = {
+    engine.bets[uid] = {
         "amount": 10.0,
         "auto": None,
         "cashed": False,
         "payout": None,
         "cash_at": None,
     }
-    r1 = client.post("/crash/cashout", cookies={"player_id": pid})
+    r1 = client.post("/crash/cashout", headers=headers)
     assert r1.status_code == 200
     data1 = r1.json()
-    r2 = client.post("/crash/cashout", cookies={"player_id": pid})
+    r2 = client.post("/crash/cashout", headers=headers)
     assert r2.status_code == 200
     assert r2.json() == data1
+
+
+def test_wallet_and_cashout_flow():
+    uid, headers = _register_user("d@example.com")
+    engine = main.app.state.crash_engine
+    engine.started = True  # evitar autostart
+    r = client.post("/crash/bet", json={"amount": 10}, headers=headers)
+    assert r.status_code == 201
+    bal_after_bet = client.get("/wallet/balance", headers=headers).json()["balance"]
+    assert bal_after_bet == 90.0
+    engine.phase = "RUNNING"
+    engine.multiplier = 2.0
+    engine.crash_at = 10.0
+    r2 = client.post("/crash/cashout", headers=headers)
+    assert r2.status_code == 200
+    bal_after_cash = client.get("/wallet/balance", headers=headers).json()["balance"]
+    assert bal_after_cash == 110.0
+    with db.SessionLocal() as s:
+        bet = s.scalar(select(CrashBet))
+        assert bet.status == "CASHED"
+
+
+def test_phase_cycle():
+    uid, headers = _register_user("e@example.com")
+    engine = main.app.state.crash_engine
+    engine._gen_crash_at = lambda: 1.01
+    r = client.post("/crash/bet", json={"amount": 10}, headers=headers)
+    assert r.status_code == 201
+    # esperar a que crashee y reinicie
+    time.sleep(0.5)
+    assert engine.phase == "BETTING"


### PR DESCRIPTION
## Summary
- add persistent crash rounds and bets tables
- hook crash engine into database and wallet transactions
- cover cashout flow, wallet balance, and phase cycle with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb331f97548328a57dda4030e812e6